### PR TITLE
Enhance build target, add RV IP core specific features

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -7,6 +7,12 @@ target = "riscv32imafc-unknown-none-elf"
 runner = "probe-rs run --chip HPM5361 --protocol jtag"
 
 rustflags = [
+    # Target features:
+    # The default for imacf is is "+m,+a,+c,+f"
+    # HPM6xxx does not have B extension
+    "-C",
+    "target-feature=+d,+zba,+zbb,+zbc,+zbs",
+    # Linker scripts:
     "-C",
     "link-arg=-Tmemory.x",
     "-C",

--- a/examples/blinky.rs
+++ b/examples/blinky.rs
@@ -2,11 +2,11 @@
 #![no_std]
 
 use embedded_hal::delay::DelayNs;
-use hpm_hal::gpio::{Level, Output, Speed};
+use hal::gpio::{Level, Output, Speed};
 use riscv::delay::McycleDelay;
 use {defmt_rtt as _, hpm_hal as hal, panic_halt as _, riscv_rt as _};
 
-#[riscv_rt::entry]
+#[hal::entry]
 fn main() -> ! {
     let p = hal::init(Default::default());
 
@@ -14,7 +14,8 @@ fn main() -> ! {
 
     defmt::info!("Board init!");
 
-    let mut led = Output::new(p.PA23, Level::Low, Speed::default());
+    let mut led = Output::new(p.PA10, Level::Low, Speed::default());
+    // let mut led = Output::new(p.PA23, Level::Low, Speed::default());
 
     loop {
         defmt::info!("tick");

--- a/examples/i2c_oled.rs
+++ b/examples/i2c_oled.rs
@@ -297,8 +297,8 @@ fn main() -> ! {
 
         // 24MHz * 40 = 960MHz
         // PLL0CLK0 = 960 M
-        // PLL0CLK1 = 960 / 1.2 = 800 M
-        // PLL0CLK2 = 960 / 1.6 = 600 M
+        // PLL0CLK1 = 960 / 1.6 = 600 M
+        // PLL0CLK2 = 960 / 2.4 = 400 M
         config.sysctl.pll0 = Some(Pll {
             mfi: 40,
             mfn: 0,


### PR DESCRIPTION
To test RV32 B extension:

```rust
        let a = 1;
        let mut b = 0_u32;
        unsafe {
            asm!("bclri {res}, {input}, 0",
                input = in(reg) a,
                res = out(reg) b,
            )
        }
        defmt::info!("bclri: {}", b);
```