### PR TITLE
Add MBX support, mailbox for communication across multicore or RTOS tasks

### DIFF
--- a/examples/embassy_mbx_fifo.rs
+++ b/examples/embassy_mbx_fifo.rs
@@ -1,0 +1,61 @@
+#![no_main]
+#![no_std]
+#![feature(type_alias_impl_trait)]
+#![feature(abi_riscv_interrupt)]
+
+use embassy_executor::Spawner;
+use embassy_time::Timer;
+use futures_util::StreamExt;
+use hal::gpio::{Level, Output};
+use hal::mbx::Mbx;
+use hal::{bind_interrupts, peripherals};
+use {defmt_rtt as _, hpm_hal as hal};
+
+bind_interrupts!(struct Irqs {
+    MBX0A => hal::mbx::InterruptHandler<peripherals::MBX0A>;
+    MBX0B => hal::mbx::InterruptHandler<peripherals::MBX0B>;
+});
+
+#[embassy_executor::task]
+async fn mailbox(mbx: Mbx<'static>) {
+    let mut mbx = mbx;
+    let mut i = 1;
+    loop {
+        defmt::info!("[task0] sending {}", i);
+        mbx.send_fifo(i).await;
+        i += 1;
+
+        Timer::after_millis(100).await;
+    }
+}
+
+#[embassy_executor::main(entry = "hpm_hal::entry")]
+async fn main(spawner: Spawner) -> ! {
+    let p = hal::init(Default::default());
+
+    defmt::info!("Board init!");
+
+    let mut led = Output::new(p.PA10, Level::Low, Default::default());
+
+    let inbox = Mbx::new(p.MBX0A, Irqs);
+    let mut outbox = Mbx::new(p.MBX0B, Irqs);
+
+    spawner.spawn(mailbox(inbox)).unwrap();
+    defmt::info!("Mailbox task spawned!");
+
+    loop {
+        led.toggle();
+
+        while let Some(val) = outbox.next().await {
+            defmt::info!("[main] receive: {}", val);
+            Timer::after_millis(1000).await; // slower
+        }
+    }
+}
+
+#[panic_handler]
+fn panic(_info: &core::panic::PanicInfo) -> ! {
+    defmt::info!("Panic!");
+
+    loop {}
+}

--- a/examples/embassy_mbx_message.rs
+++ b/examples/embassy_mbx_message.rs
@@ -1,0 +1,58 @@
+#![no_main]
+#![no_std]
+#![feature(type_alias_impl_trait)]
+#![feature(abi_riscv_interrupt)]
+
+use embassy_executor::Spawner;
+use embassy_time::Timer;
+use hal::gpio::{Level, Output};
+use hal::mbx::Mbx;
+use hal::{bind_interrupts, peripherals};
+use {defmt_rtt as _, hpm_hal as hal};
+
+bind_interrupts!(struct Irqs {
+    MBX0A => hal::mbx::InterruptHandler<peripherals::MBX0A>;
+    MBX0B => hal::mbx::InterruptHandler<peripherals::MBX0B>;
+});
+
+#[embassy_executor::task]
+async fn mailbox(mbx: Mbx<'static>) {
+    let mut mbx = mbx;
+    let mut i = 114514;
+    loop {
+        defmt::info!("[task0] sending {}", i);
+        mbx.send(i).await;
+        i += 1;
+
+        Timer::after_millis(100).await;
+    }
+}
+
+#[embassy_executor::main(entry = "hpm_hal::entry")]
+async fn main(spawner: Spawner) -> ! {
+    let p = hal::init(Default::default());
+
+    defmt::info!("Board init!");
+
+    let mut led = Output::new(p.PA10, Level::Low, Default::default());
+
+    let inbox = Mbx::new(p.MBX0A, Irqs);
+    let mut outbox = Mbx::new(p.MBX0B, Irqs);
+
+    spawner.spawn(mailbox(inbox)).unwrap();
+    defmt::info!("Mailbox task spawned!");
+
+    loop {
+        led.toggle();
+
+        let val = outbox.recv().await;
+        defmt::info!("[main] receive: {}", val);
+    }
+}
+
+#[panic_handler]
+fn panic(_info: &core::panic::PanicInfo) -> ! {
+    defmt::info!("Panic!");
+
+    loop {}
+}

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -24,6 +24,29 @@ macro_rules! peri_trait {
     };
 }
 
+macro_rules! peri_trait_without_sysclk {
+    (
+        $(irqs: [$($irq:ident),*],)?
+    ) => {
+        #[allow(private_interfaces)]
+        pub(crate) trait SealedInstance {
+            #[allow(unused)]
+            fn info() -> &'static Info;
+            #[allow(unused)]
+            fn state() -> &'static State;
+        }
+
+        /// Peripheral instance trait.
+        #[allow(private_bounds)]
+        pub trait Instance: crate::Peripheral<P = Self> + SealedInstance {
+            $($(
+                /// Interrupt for this peripheral.
+                type $irq: crate::interrupt::typelevel::Interrupt;
+            )*)?
+        }
+    };
+}
+
 macro_rules! peri_trait_impl {
     ($instance:ident, $info:expr) => {
         #[allow(private_interfaces)]

--- a/src/mbx.rs
+++ b/src/mbx.rs
@@ -1,0 +1,123 @@
+//! Mailbox
+//!
+//!
+
+use core::marker::PhantomData;
+
+use embassy_hal_internal::{into_ref, Peripheral, PeripheralRef};
+use embassy_sync::waitqueue::AtomicWaker;
+
+use crate::{interrupt, pac, peripherals};
+
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum Error {
+    Reading,
+    Writing,
+    FifoFull,
+    FiflEmpty,
+    AccessInvalid,
+    WriteToReadOnly,
+}
+
+pub struct InterruptHandler<T: Instance> {
+    _phantom: PhantomData<T>,
+}
+
+impl<T: Instance> interrupt::typelevel::Handler<T::Interrupt> for InterruptHandler<T> {
+    unsafe fn on_interrupt() {
+        todo!()
+    }
+}
+
+pub struct Mailbox<'d, T: Instance> {
+    _inner: PeripheralRef<'d, T>,
+}
+
+impl<'d, T: Instance> Mailbox<'d, T> {
+    pub fn new(
+        inner: impl Peripheral<P = T> + 'd,
+        _irq: impl interrupt::typelevel::Binding<T::Interrupt, InterruptHandler<T>> + 'd,
+    ) -> Self {
+        into_ref!(inner);
+
+        let r = T::regs();
+
+        r.cr().modify(|w| w.set_txreset(true));
+        r.cr().modify(|w| w.set_txreset(false));
+
+        Self { _inner: inner }
+    }
+
+    pub fn blocking_send(&mut self, data: u32) {
+        let r = T::regs();
+
+        // tx word message empty
+        while !r.sr().read().twme() {}
+        r.txreg().write(|w| w.0 = data);
+    }
+
+    pub fn blocking_receive(&mut self) -> u32 {
+        let r = T::regs();
+
+        // rx word message valid
+        while !r.sr().read().rwmv() {}
+        r.rxreg().read().0
+    }
+
+    pub fn nb_send(&mut self, data: u32) -> nb::Result<(), Error> {
+        let r = T::regs();
+
+        if r.sr().read().twme() {
+            r.txreg().write(|w| w.0 = data);
+            Ok(())
+        } else {
+            Err(nb::Error::WouldBlock)
+        }
+    }
+
+    pub fn nb_receive(&mut self) -> nb::Result<u32, Error> {
+        let r = T::regs();
+
+        if r.sr().read().rwmv() {
+            Ok(r.rxreg().read().0)
+        } else {
+            Err(nb::Error::WouldBlock)
+        }
+    }
+}
+
+impl<'d, T: Instance> Drop for Mailbox<'d, T> {
+    fn drop(&mut self) {
+        let r = T::regs();
+
+        r.cr().modify(|w| {
+            w.0 = 0;
+        }); // disable all interrupts
+    }
+}
+
+trait SealedInstance {
+    fn regs() -> pac::mbx::Mbx;
+}
+
+#[allow(private_bounds)]
+pub trait Instance: SealedInstance + Peripheral<P = Self> + 'static + Send {
+    /// Interrupt for this RNG instance.
+    type Interrupt: interrupt::typelevel::Interrupt;
+}
+
+foreach_peripheral!(
+    (mbx, $inst:ident) => {
+        #[allow(private_interfaces)]
+        impl SealedInstance for peripherals::$inst {
+            fn regs() -> pac::mbx::Mbx {
+                pac::$inst
+            }
+        }
+
+        impl Instance for peripherals::$inst {
+            type Interrupt = crate::interrupt::typelevel::$inst;
+        }
+    };
+);

--- a/src/mbx.rs
+++ b/src/mbx.rs
@@ -1,4 +1,4 @@
-//! Mailbox
+//! MBX, mailbox, for inter core communication and inter task communication.
 //!
 //! - message word(u32): send/recv interface
 //! - message queue(fifo): send_fifo/recv_fifo/Stream interface
@@ -55,11 +55,11 @@ impl<T: Instance> interrupt::typelevel::Handler<T::Interrupt> for InterruptHandl
     }
 }
 
-pub struct Mailbox<'d, T: Instance> {
+pub struct Mbx<'d, T: Instance> {
     _inner: PeripheralRef<'d, T>,
 }
 
-impl<'d, T: Instance> Mailbox<'d, T> {
+impl<'d, T: Instance> Mbx<'d, T> {
     pub fn new(
         inner: impl Peripheral<P = T> + 'd,
         _irq: impl interrupt::typelevel::Binding<T::Interrupt, InterruptHandler<T>> + 'd,
@@ -194,7 +194,7 @@ impl<'d, T: Instance> Mailbox<'d, T> {
 }
 
 // TODO: migrate impl to AsyncIterator
-impl<'d, T: Instance> stream::Stream for Mailbox<'d, T> {
+impl<'d, T: Instance> stream::Stream for Mbx<'d, T> {
     type Item = u32;
 
     fn poll_next(self: core::pin::Pin<&mut Self>, cx: &mut core::task::Context<'_>) -> Poll<Option<Self::Item>> {
@@ -211,7 +211,7 @@ impl<'d, T: Instance> stream::Stream for Mailbox<'d, T> {
     }
 }
 
-impl<'d, T: Instance> Drop for Mailbox<'d, T> {
+impl<'d, T: Instance> Drop for Mbx<'d, T> {
     fn drop(&mut self) {
         let r = T::regs();
 


### PR DESCRIPTION
- message word(u32) API: send/recv interface
- message queue(FIFO) API: send_fifo/recv_fifo/Stream interface
- [x] Demo code
- [x] Design consideration: eliminate peripheral generic parameter? - DONE

Demo usage:

```rust
bind_interrupts!(struct Irqs {
    MBX0A => hal::mbx::InterruptHandler<peripherals::MBX0A>;
    MBX0B => hal::mbx::InterruptHandler<peripherals::MBX0B>;
});


#[embassy_executor::task]
async fn mailbox(mbox: Mbx<'static>) {
    let mut mbox = mbox;
    let mut i = 345;
    loop {
        defmt::info!("[task0] sending {}", i);
        mbox.send_fifo(i).await; // will block until fifo has space
        i += 1;

        Timer::after_millis(100).await; // faster
    }
}

let mut outbox = Mbx::new(p.MBX0B, Irqs);
while let Some(val) = outbox.next().await {
            defmt::info!("[main] Received: {}", val);
            Timer::after_millis(1000).await; // slower
}

```