### PR TITLE
HPM6E00 basic support

### DIFF
--- a/HPMicro.yaml
+++ b/HPMicro.yaml
@@ -1,64 +1,139 @@
 name: HPMicro
 variants:
-- name: HPM5361
-  cores:
-  - name: core0
-    type: riscv
-    core_access_options: !Riscv {}
-  memory_map:
-  - !Ram
-    name: ILM0
-    range:
-      start: 0x0
-      end: 0x20000
+  - name: HPM5361
     cores:
-    - core0
-  - !Ram
-    name: DLM0
-    range:
-      start: 0x80000
-      end: 0xa0000
+      - name: core0
+        type: riscv
+        core_access_options: !Riscv {}
+    memory_map:
+      - !Ram
+        name: ILM0
+        range:
+          start: 0x0
+          end: 0x20000
+        cores:
+          - core0
+      - !Ram
+        name: DLM0
+        range:
+          start: 0x80000
+          end: 0xa0000
+        cores:
+          - core0
+      - !Ram
+        name: AHB_SRAM
+        range:
+          start: 0xf0400000
+          end: 0xf0408000
+        cores:
+          - core0
+      - !Nvm
+        name: XPI0
+        range:
+          start: 0x80000000
+          end: 0x80100000
+        is_boot_memory: true
+        cores:
+          - core0
+    flash_algorithms:
+      - flash-algo-hpm5300
+  - name: HPM6E80
     cores:
-    - core0
-  - !Ram
-    name: AHB_SRAM
-    range:
-      start: 0xf0400000
-      end: 0xf0408000
-    cores:
-    - core0
-  - !Nvm
-    name: XPI0
-    range:
-      start: 0x80000000
-      end: 0x80100000
-    is_boot_memory: true
-    cores:
-    - core0
-  flash_algorithms:
-  - algorithm-test
+      - name: core0
+        type: riscv
+        core_access_options: !Riscv {}
+    memory_map:
+      - !Ram
+        name: ILM0
+        range:
+          start: 0x0
+          end: 0x40000
+        cores:
+          - core0
+      - !Ram
+        name: DLM0
+        range:
+          start: 0x00200000
+          end: 0x00240000
+        cores:
+          - core0
+      - !Ram
+        name: ILM1_ALS
+        range:
+          start: 0x01300000
+          end: 0x01340000
+        cores:
+          - core0
+      - !Ram
+        name: DLM1_ALS
+        range:
+          start: 0x01340000
+          end: 0x01380000
+        cores:
+          - core0
+      - !Ram
+        name: AXI_SRAM
+        range:
+          start: 0x01200000
+          end: 0x01300000
+        cores:
+          - core0
+      - !Nvm
+        name: XPI0
+        range:
+          start: 0x80000000
+          end: 0x90000000
+        is_boot_memory: true
+        cores:
+          - core0
+    flash_algorithms:
+      - flash-algo-hpm6e00
 flash_algorithms:
-- name: algorithm-test
-  description: A flash algorithm under test
-  default: true
-  instructions: EwEB3CMuESIjLIEiIyqRIiMoISO3BQAABUV9Fo1GI4SlSGN51gy3FQD0A6AFgH1WI6DFgAOgBYEjqMWAI6KlkGgAEwYAEIFFlwAAAOeAAC8jLgEQIywBEDcF+fwJBSMmoRAZRSMooRAFZSMqoRA3BQIgAyVF8XRF0cI3BQDzbABwAjcJAPOCliqEKemyRCMAAQQMCAgSEwbAD5cAAADngAAWaAxsAlFGlwAAAOeAIBU3BQAAIyiVNpMEBTcThUQADBITBgARlwAAAOeAQBMjqiQRNwUAAIVFIwS1SCKFgyDBIwMkgSODJEEjAykBIxMBASSCgJcAAADngEANlwAAAOeAwA63BQAAA8aFSAVFAcYBRSOEBUiCgLcFAACDxYVIncG3BQIgg6VF8ZxRmc+3BQAAE4YFNwMnRhG3BgCAqY6RRTqFgocFRYKAlwAAAOeA4Am3BgAAA8eGSAXLLoi3BQIgg6VF8QOjhQJjAgMCsoa3BQAAE4YFN4MnRhE3BwCAKY+RRT6FwocCgwVFgoCXAAAA54CgBTcFAAADRYVIGc03BQIgAyVF8VxNmcs3BQAAEwYFNwMlRhGRRYKHBUWCgJcAAADngIACQREGxiLEAAiXAAAA54CAAkERBsYixAAIlwAAAOeAgP5BEQbGIsQACJcAAADngID+AaBBEQbGIsQACLJAIkRBARcDAABnAIMAQREGxiLEAAjBRmNr1gazBqBAE/g2ALMDBQFjDAgAqoeuhgPHBgAjgOcAhQeFBuPqd/6ziAUBMwgGQZNyyP+T9TgAs4ZTAKHBY1lQBJOVOAAT84UBk/fI/5BDswWwQBP+hQGRB5hDM1ZmALMVxwHRjSOgswCRA5EHOobj5dP+Maiqhg3iDahjWlAAxoWQQSOgwwCRA5EF4+vT/rOFWAATdjgAEco2lgPHBQAjgOYAhQaFBePqxv6yQCJEQQGCgEERBsYixAAIwUZjZNYEswagQI2KMwfVAJnGqocjgLcAhQfj7ef+FY6Td8b/swb3AGNe8AAT+PUPtwcBAZOHFxCzB/gCHMMRB+Nu1/4NigHmCaiqhhnGNpYjgLYAhQbj7cb+skAiREEBgoBBEQbGIsQACLJAIkRBARcDAABnAIP4AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
-  load_address: 0x20
-  pc_init: 0x0
-  pc_uninit: 0x104
-  pc_program_page: 0x152
-  pc_erase_sector: 0x118
-  pc_erase_all: 0x196
-  data_section_offset: 0x468
-  flash_properties:
-    address_range:
-      start: 0x80000000
-      end: 0x80100000
-    page_size: 0x1000
-    erased_byte_value: 0xff
-    program_page_timeout: 1000
-    erase_sector_timeout: 2000
-    sectors:
-    - size: 0x1000
-      address: 0x0
-  cores:
-  - core0
+  - name: flash-algo-hpm5300
+    description: A flash algorithm under test
+    default: true
+    instructions: EwEB3CMuESIjLIEiIyqRIiMoISO3BQAABUV9Fo1GI4SlSGN51gy3FQD0A6AFgH1WI6DFgAOgBYEjqMWAI6KlkGgAEwYAEIFFlwAAAOeAAC8jLgEQIywBEDcF+fwJBSMmoRAZRSMooRAFZSMqoRA3BQIgAyVF8XRF0cI3BQDzbABwAjcJAPOCliqEKemyRCMAAQQMCAgSEwbAD5cAAADngAAWaAxsAlFGlwAAAOeAIBU3BQAAIyiVNpMEBTcThUQADBITBgARlwAAAOeAQBMjqiQRNwUAAIVFIwS1SCKFgyDBIwMkgSODJEEjAykBIxMBASSCgJcAAADngEANlwAAAOeAwA63BQAAA8aFSAVFAcYBRSOEBUiCgLcFAACDxYVIncG3BQIgg6VF8ZxRmc+3BQAAE4YFNwMnRhG3BgCAqY6RRTqFgocFRYKAlwAAAOeA4Am3BgAAA8eGSAXLLoi3BQIgg6VF8QOjhQJjAgMCsoa3BQAAE4YFN4MnRhE3BwCAKY+RRT6FwocCgwVFgoCXAAAA54CgBTcFAAADRYVIGc03BQIgAyVF8VxNmcs3BQAAEwYFNwMlRhGRRYKHBUWCgJcAAADngIACQREGxiLEAAiXAAAA54CAAkERBsYixAAIlwAAAOeAgP5BEQbGIsQACJcAAADngID+AaBBEQbGIsQACLJAIkRBARcDAABnAIMAQREGxiLEAAjBRmNr1gazBqBAE/g2ALMDBQFjDAgAqoeuhgPHBgAjgOcAhQeFBuPqd/6ziAUBMwgGQZNyyP+T9TgAs4ZTAKHBY1lQBJOVOAAT84UBk/fI/5BDswWwQBP+hQGRB5hDM1ZmALMVxwHRjSOgswCRA5EHOobj5dP+Maiqhg3iDahjWlAAxoWQQSOgwwCRA5EF4+vT/rOFWAATdjgAEco2lgPHBQAjgOYAhQaFBePqxv6yQCJEQQGCgEERBsYixAAIwUZjZNYEswagQI2KMwfVAJnGqocjgLcAhQfj7ef+FY6Td8b/swb3AGNe8AAT+PUPtwcBAZOHFxCzB/gCHMMRB+Nu1/4NigHmCaiqhhnGNpYjgLYAhQbj7cb+skAiREEBgoBBEQbGIsQACLJAIkRBARcDAABnAIP4AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+    load_address: 0x20
+    pc_init: 0x0
+    pc_uninit: 0x104
+    pc_program_page: 0x152
+    pc_erase_sector: 0x118
+    pc_erase_all: 0x196
+    data_section_offset: 0x468
+    flash_properties:
+      address_range:
+        start: 0x80000000
+        end: 0x80100000
+      page_size: 0x1000
+      erased_byte_value: 0xff
+      program_page_timeout: 1000
+      erase_sector_timeout: 2000
+      sectors:
+        - size: 0x1000
+          address: 0x0
+    cores:
+      - core0
+  - name: flash-algo-hpm6e00
+    description: A flash algorithm under test
+    default: true
+    instructions: EwEB3CMuESIjLIEiIyqRIiMoISO3BQAABUV9Fo1GI4qlSGNw1g63FQD0A6AFgH1WI6DFgAOgBYEjqMWAA6AFgiOgxYIDoAWDI6jFgiOipZBoABMGABCBRZcAAADngOAuIy4BECMsARA3Bfn8BQUjJqEQHUUjKKEQIyoBEDcFAiADJUXxdEXRwjcFAPNsAHACNwkA84KWKoQp6bJEIwABBAwICBITBsAPlwAAAOeAABZoDGwCUUaXAAAA54AgFTcFAAAjLpU2kwTFNxOFRAAMEhMGABGXAAAA54BAEyOqJBE3BQAAhUUjCrVIIoWDIMEjAySBI4MkQSMDKQEjEwEBJIKAlwAAAOeAQA2XAAAA54DADrcFAAADxkVJBUUBxgFFI4oFSIKAtwUAAIPFRUmdwbcFAiCDpUXxnFGZz7cFAAAThsU3AydGEbcGAICpjpFFOoWChwVFgoCXAAAA54DgCbcGAAADx0ZJBcsuiLcFAiCDpUXxA6OFAmMCAwKyhrcFAAAThsU3gydGETcHAIApj5FFPoXChwKDBUWCgJcAAADngKAFNwUAAANFRUkZzTcFAiADJUXxXE2ZyzcFAAATBsU3AyVGEZFFgocFRYKAlwAAAOeAgAJBEQbGIsQACJcAAADngIACQREGxiLEAAiXAAAA54CA/kERBsYixAAIlwAAAOeAgP4BoEERBsYixAAIskAiREEBFwMAAGcAgwBBEQbGIsQACMFGY2vWBrMGoEAT+DYAswMFAWMMCACqh66GA8cGACOA5wCFB4UG4+p3/rOIBQEzCAZBk3LI/5P1OACzhlMAocFjWVAEk5U4ABPzhQGT98j/kEOzBbBAE/6FAZEHmEMzVmYAsxXHAdGNI6CzAJEDkQc6huPl0/4xqKqGDeINqGNaUADGhZBBI6DDAJEDkQXj69P+s4VYABN2OAARyjaWA8cFACOA5gCFBoUF4+rG/rJAIkRBAYKAQREGxiLEAAjBRmNk1gSzBqBAjYozB9UAmcaqhyOAtwCFB+Pt5/4VjpN3xv+zBvcAY17wABP49Q+3BwEBk4cXELMH+AIcwxEH427X/g2KAeYJqKqGGcY2liOAtgCFBuPtxv6yQCJEQQGCgEERBsYixAAIskAiREEBFwMAAGcAg/gAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+    load_address: 0x20
+    pc_init: 0x0
+    pc_uninit: 0x112
+    pc_program_page: 0x160
+    pc_erase_sector: 0x126
+    pc_erase_all: 0x1a4
+    data_section_offset: 0x474
+    flash_properties:
+      address_range:
+        start: 0x80000000
+        end: 0x90000000
+      page_size: 0x1000
+      erased_byte_value: 0xff
+      program_page_timeout: 1000
+      erase_sector_timeout: 2000
+      sectors:
+        - size: 0x1000
+          address: 0x0
+    cores:
+      - core0

--- a/README.md
+++ b/README.md
@@ -19,7 +19,8 @@ This crate is a working-in-progress and not ready for use.
   - [x] I2C blocking
   - [x] MBX, blocking and async
 - MCUs
-  - HPM5300 - currently it's the only supported series
+  - HPM5300
+  - HPM6E00, without PLL setting
 
 ### Toolchain Support
 
@@ -27,9 +28,46 @@ This crate is a working-in-progress and not ready for use.
   - [x] [HPM5300 series flash algorithm support](https://github.com/probe-rs/probe-rs/pull/2575)
   - [ ] [JTag support for DAPLink](https://github.com/probe-rs/probe-rs/pull/2578)
 
+## Usage
+
+The best reference is the examples in the `examples` directory and Github actions workflow.
+
+To get it compile, you might need to use the [hpm-metapac] snapshot repo, or build from [hpm-data] yourself.
+
+Edit the `Cargo.toml` to use the git-based dependency:
+
+```toml
+hpm-metapac = { version = "0.0.3", git = "https://github.com/hpmicro-rs/hpm-metapac.git", tag="hpm-data-d9f90671e5b8ebd51c9565484919b4b880b6a23a" }
+```
+
+### Requirements
+
+- A probe(debugger), optional if you are using official HPMicro's development board
+  - FT2232-based (official HPMicro's development board uses this chip)
+  - JLink
+  - DAPLink-based probe
+- A flash tool for your probe, choose one from:
+  - [probe-rs]
+  - [HPM OpenOCD]
+  - JLink
+  - HPMIcro Manufacturing Tool
+- A RISC-V GCC toolchain if you perfer to use OpenOCD(only GDB is needed)
+- A Rust toolchain
+  - `rustup default nightly-2024-06-12` (locked because of bug [rust-embedded/riscv#196](https://github.com/rust-embedded/riscv/issues/196))
+  - `rustup target add riscv32imafc-unknown-none-elf`
+
+### Run the examples
+
+```bash
+cd examples/hpm5300evk
+cargo run --release --bin blinky
+```
+
 ## Contributing
 
 This crate is under active development. Before starting your work, it's better to create a "Work in Progress" (WIP) pull request describing your work to avoid conflicts.
 
 [hpm-data]: https://github.com/andelf/hpm-data
 [probe-rs]: https://github.com/probe-rs/probe-rs
+[hpm-metapac]: https://github.com/hpmicro-rs/hpm-metapac
+[HPM OpenOCD]: https://github.com/hpmicro/riscv-openocd

--- a/examples/hpm6e00evk/.cargo/config.toml
+++ b/examples/hpm6e00evk/.cargo/config.toml
@@ -2,9 +2,8 @@
 target = "riscv32imafc-unknown-none-elf"
 
 [target.riscv32imafc-unknown-none-elf]
-runner = 'riscv64-unknown-elf-gdb -x ../../openocd.gdb'
-# runner = "probe-rs run --chip HPM6E80 --protocol jtag --chip-description-path ./HPMicro.yaml"
-# runner = "probe-rs run --chip HPM6E80 --protocol jtag"
+# runner = 'riscv64-unknown-elf-gdb -x ../../openocd.gdb'
+runner = "probe-rs run --chip HPM6E80 --protocol jtag --chip-description-path ../../HPMicro.yaml"
 
 rustflags = [
     # Target features:

--- a/examples/hpm6e00evk/.cargo/config.toml
+++ b/examples/hpm6e00evk/.cargo/config.toml
@@ -9,7 +9,7 @@ rustflags = [
     # Target features:
     # The default for imacf is is "+m,+a,+c,+f"
     "-C",
-    "target-feature=+d,+zba,+zbb,+zbc,+zbs",
+    "target-feature=+zba,+zbb,+zbc,+zbs",
     # Linker scripts:
     "-C",
     "link-arg=-Tmemory.x",

--- a/examples/hpm6e00evk/Cargo.toml
+++ b/examples/hpm6e00evk/Cargo.toml
@@ -5,12 +5,7 @@ edition = "2021"
 resolver = "2"
 
 [dependencies]
-# git = "https://github.com/hpmicro-rs/hpm-metapac.git", tag = "hpm-data-86124df0e9c855436aecece4a17469dd7ac6baf6",
-hpm-metapac = { version = "0.0.3", path = "../../../hpm-data/build/hpm-metapac", features = [
-    "rt",
-    "pac",
-    "hpm6e80",
-] }
+hpm-hal = { path = "../../", features = ["hpm6e80"] }
 
 # TODO
 # hpm-hal = { path = "../../", features = ["hpm6e80"]}
@@ -21,7 +16,15 @@ defmt = "0.3.8"
 defmt-rtt = "0.4.1"
 embedded-hal = "1.0.0"
 riscv = { version = "0.11.1", features = ["critical-section-single-hart"] }
+heapless = "0.8.0"
 
+embassy-time = { version = "0.3.0", features = ["tick-hz-1_000_000"] }
+embassy-executor = { version = "0.5.0", features = [
+    "nightly",
+    "integrated-timers",
+    "arch-riscv32",
+    "executor-thread",
+] }
 
 [profile.release]
 strip = false   # symbols are not flashed to the microcontroller, so don't strip them.

--- a/examples/hpm6e00evk/src/bin/blinky.rs
+++ b/examples/hpm6e00evk/src/bin/blinky.rs
@@ -2,63 +2,37 @@
 #![no_std]
 
 use embedded_hal::delay::DelayNs;
-use hpm_metapac::gpiom::vals;
+use hal::pac;
+use hpm_hal::gpio::{Level, Output};
 use riscv::delay::McycleDelay;
-use {defmt_rtt as _, hpm_metapac as pac, panic_halt as _, riscv_rt as _};
+use {defmt_rtt as _, hpm_hal as hal, panic_halt as _, riscv_rt as _};
 
-#[riscv_rt::entry]
+#[hal::entry]
 fn main() -> ! {
+    let p = hal::init(Default::default());
     // default clock
-    let mut delay = McycleDelay::new(600_000_000);
+    let mut delay = McycleDelay::new(hal::sysctl::clocks().cpu0.0);
 
-    // ugly but works
-    pac::SYSCTL.group0(0).set().modify(|w| w.0 = 0xFFFFFFFF);
-    pac::SYSCTL.group0(1).set().modify(|w| w.0 = 0xFFFFFFFF);
-    pac::SYSCTL.group0(2).set().modify(|w| w.0 = 0xFFFFFFFF);
-    pac::SYSCTL.group0(3).set().modify(|w| w.0 = 0xFFFFFFFF);
+    // all leds are active low
 
-    pac::SYSCTL.affiliate(0).set().write(|w| w.set_link(1));
-
-    /*
-    pac::IOC.pad(142).func_ctl().modify(|w| w.set_alt_select(0));
-    pac::IOC.pad(142).pad_ctl().write(|w| {
-        w.set_pe(true);
-    });
-    */
-
-    const PE: usize = 4;
-    pac::GPIOM.assign(PE).pin(14).modify(|w| {
-        w.set_select(vals::PinSelect::CPU0_FGPIO); // FGPIO0
-        w.set_hide(0b01); // invisible to GPIO0
-    });
-    pac::GPIOM.assign(PE).pin(15).modify(|w| {
-        w.set_select(vals::PinSelect::CPU0_FGPIO); // FGPIO0
-        w.set_hide(0b01); // invisible to GPIO0
-    });
-    pac::GPIOM.assign(PE).pin(4).modify(|w| {
-        w.set_select(vals::PinSelect::CPU0_FGPIO); // FGPIO0
-        w.set_hide(0b01); // invisible to GPIO0
-    });
-
-    pac::FGPIO
-        .oe(PE)
-        .set()
-        .write(|w| w.set_direction((1 << 14) | (1 << 15) | (1 << 4)));
+    let mut r = Output::new(p.PE14, Level::Low, Default::default());
+    let mut g = Output::new(p.PE15, Level::Low, Default::default());
+    let mut b = Output::new(p.PE04, Level::Low, Default::default());
 
     defmt::info!("Board init!");
 
     loop {
         defmt::info!("tick");
 
-        pac::FGPIO.do_(PE).toggle().write(|w| w.set_output(1 << 14));
+        r.toggle();
 
         delay.delay_ms(100);
 
-        pac::FGPIO.do_(PE).toggle().write(|w| w.set_output(1 << 15));
+        g.toggle();
 
         delay.delay_ms(100);
 
-        pac::FGPIO.do_(PE).toggle().write(|w| w.set_output(1 << 4));
+        b.toggle();
 
         delay.delay_ms(100);
     }

--- a/examples/hpm6e00evk/src/bin/blinky.rs
+++ b/examples/hpm6e00evk/src/bin/blinky.rs
@@ -59,5 +59,7 @@ fn main() -> ! {
         delay.delay_ms(100);
 
         pac::FGPIO.do_(PE).toggle().write(|w| w.set_output(1 << 4));
+
+        delay.delay_ms(100);
     }
 }

--- a/examples/hpm6e00evk/src/bin/embassy_blinky.rs
+++ b/examples/hpm6e00evk/src/bin/embassy_blinky.rs
@@ -1,0 +1,52 @@
+#![no_main]
+#![no_std]
+#![feature(type_alias_impl_trait)]
+
+use embassy_executor::Spawner;
+use embassy_time::Timer;
+use hal::gpio::Pin as _;
+use hpm_hal::gpio::{AnyPin, Level, Output};
+use {defmt_rtt as _, hpm_hal as hal, riscv_rt as _};
+
+#[embassy_executor::task(pool_size = 3)]
+async fn blink(pin: AnyPin, interval_ms: u32) {
+    // all leds are active low
+    let mut led = Output::new(pin, Level::Low, Default::default());
+
+    loop {
+        led.toggle();
+
+        Timer::after_millis(interval_ms as u64).await;
+    }
+}
+
+#[embassy_executor::main(entry = "hpm_hal::entry")]
+async fn main(spawner: Spawner) -> ! {
+    let p = hal::init(Default::default());
+
+    defmt::info!("Board init!");
+
+    spawner.spawn(blink(p.PE14.degrade(), 100)).unwrap();
+    spawner.spawn(blink(p.PE15.degrade(), 200)).unwrap();
+    spawner.spawn(blink(p.PE04.degrade(), 300)).unwrap();
+
+    defmt::info!("Tasks init!");
+
+    loop {
+        defmt::info!("tick");
+
+        Timer::after_millis(1000).await;
+    }
+}
+
+#[panic_handler]
+fn panic(_info: &core::panic::PanicInfo) -> ! {
+    let mut err = heapless::String::<1024>::new();
+
+    use core::fmt::Write as _;
+
+    write!(err, "panic: {}", _info).ok();
+
+    defmt::info!("{}", err.as_str());
+    loop {}
+}

--- a/examples/hpm6e00evk/src/bin/raw_blinky.rs
+++ b/examples/hpm6e00evk/src/bin/raw_blinky.rs
@@ -1,0 +1,66 @@
+#![no_main]
+#![no_std]
+
+use embedded_hal::delay::DelayNs;
+use hal::pac;
+use pac::gpiom::vals;
+use riscv::delay::McycleDelay;
+use {defmt_rtt as _, hpm_hal as hal, panic_halt as _, riscv_rt as _};
+
+#[riscv_rt::entry]
+fn main() -> ! {
+    // default clock
+    let mut delay = McycleDelay::new(600_000_000);
+
+    // ugly but works
+    pac::SYSCTL.group0(0).set().modify(|w| w.0 = 0xFFFFFFFF);
+    pac::SYSCTL.group0(1).set().modify(|w| w.0 = 0xFFFFFFFF);
+    pac::SYSCTL.group0(2).set().modify(|w| w.0 = 0xFFFFFFFF);
+    pac::SYSCTL.group0(3).set().modify(|w| w.0 = 0xFFFFFFFF);
+
+    pac::SYSCTL.affiliate(0).set().write(|w| w.set_link(1));
+
+    /*
+    pac::IOC.pad(142).func_ctl().modify(|w| w.set_alt_select(0));
+    pac::IOC.pad(142).pad_ctl().write(|w| {
+        w.set_pe(true);
+    });
+    */
+
+    const PE: usize = 4;
+    pac::GPIOM.assign(PE).pin(14).modify(|w| {
+        w.set_select(vals::PinSelect::CPU0_FGPIO); // FGPIO0
+        w.set_hide(0b01); // invisible to GPIO0
+    });
+    pac::GPIOM.assign(PE).pin(15).modify(|w| {
+        w.set_select(vals::PinSelect::CPU0_FGPIO); // FGPIO0
+        w.set_hide(0b01); // invisible to GPIO0
+    });
+    pac::GPIOM.assign(PE).pin(4).modify(|w| {
+        w.set_select(vals::PinSelect::CPU0_FGPIO); // FGPIO0
+        w.set_hide(0b01); // invisible to GPIO0
+    });
+
+    pac::FGPIO
+        .oe(PE)
+        .set()
+        .write(|w| w.set_direction((1 << 14) | (1 << 15) | (1 << 4)));
+
+    defmt::info!("Board init!");
+
+    loop {
+        defmt::info!("tick");
+
+        pac::FGPIO.do_(PE).toggle().write(|w| w.set_output(1 << 14));
+
+        delay.delay_ms(100);
+
+        pac::FGPIO.do_(PE).toggle().write(|w| w.set_output(1 << 15));
+
+        delay.delay_ms(100);
+
+        pac::FGPIO.do_(PE).toggle().write(|w| w.set_output(1 << 4));
+
+        delay.delay_ms(100);
+    }
+}

--- a/src/dma/dma.rs
+++ b/src/dma/dma.rs
@@ -1,0 +1,160 @@
+use core::sync::atomic::AtomicUsize;
+
+use embassy_sync::waitqueue::AtomicWaker;
+use hpm_metapac::dma::vals::AddrCtrl;
+
+use super::word::WordSize;
+use super::{AnyChannel, Request};
+use crate::interrupt::typelevel::Interrupt;
+use crate::interrupt::InterruptExt;
+
+/// DMA transfer options.
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[non_exhaustive]
+pub struct TransferOptions {
+    pub burst: Burst,
+    // /// Enable handshake, transfer by peripheral request
+    // pub handshake: bool,
+    /// Is high priority
+    pub priority: bool,
+    /// Circular transfer mode, aka. loop mode(INFINITELOOP)
+    pub circular: bool,
+    /// Enable half transfer interrupt
+    pub half_transfer_irq: bool,
+    /// Enable transfer complete interrupt
+    pub complete_transfer_irq: bool,
+    /// Transfer handshake mode
+    pub handshake: HandshakeMode,
+}
+
+impl Default for TransferOptions {
+    fn default() -> Self {
+        Self {
+            burst: Burst::Liner(1),
+            handshake: HandshakeMode::Normal,
+            priority: false,
+            circular: false,
+            half_transfer_irq: false,
+            complete_transfer_irq: true,
+        }
+    }
+}
+
+/// DMA transfer burst setting.
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum Burst {
+    // 0:1transfer; 0xf: 16 transfer
+    Liner(u8),
+    /*
+    0x0: 1 transfer
+    0x1: 2 transfers
+    0x2: 4 transfers
+    0x3: 8 transfers
+    0x4: 16 transfers
+    0x5: 32 transfers
+    0x6: 64 transfers
+    0x7: 128 transfers
+    0x8: 256 transfers
+    0x9:512 transfers
+    0xa: 1024 transfers
+    */
+    Exponential(u8),
+}
+
+pub(crate) struct ChannelState {
+    waker: AtomicWaker,
+    complete_count: AtomicUsize,
+}
+
+impl ChannelState {
+    pub(crate) const NEW: Self = Self {
+        waker: AtomicWaker::new(),
+        complete_count: AtomicUsize::new(0),
+    };
+}
+
+pub(crate) unsafe fn init(cs: critical_section::CriticalSection) {
+    use crate::interrupt;
+
+    interrupt::typelevel::HDMA::set_priority_with_cs(cs, interrupt::Priority::P1);
+
+    // TODO: init dma cpu group link
+}
+
+// TODO: on_irq, on DMA handler level
+unsafe fn on_interrupt() {
+    defmt::info!("in irq");
+
+    crate::interrupt::HDMA.complete(); // notify PLIC
+}
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[non_exhaustive]
+pub enum HandshakeMode {
+    /// Software enable contro
+    Normal,
+    /// Source DMAMUX request
+    Source,
+    /// Destination DMAMUX request
+    Destination,
+}
+
+impl AnyChannel {
+    unsafe fn configure(
+        &self,
+        request: Request, // DMA request number in DMAMUX
+        src_addr: *const u32,
+        src_width: WordSize,
+        src_addr_ctrl: AddrCtrl,
+        dst_addr: *mut u32,
+        dst_width: WordSize,
+        dst_addr_ctrl: AddrCtrl,
+        // TRANSIZE
+        size_in_bytes: usize,
+        options: TransferOptions,
+    ) {
+        let info = self.info();
+
+        let r = info.dma.regs();
+        let ch = info.num; // channel number in current dma controller
+        let mux_ch = info.mux_num; // channel number in dma mux, (XDMA_CH0 = HDMA_CH31+1 = 32)
+
+        // follow the impl of dma_setup_channel
+
+        // configure DMAMUX request and output channel
+        super::dmamux::configure_dmamux(info.mux_num, request);
+
+        // check alignment
+        if !dst_width.aligned(size_in_bytes as u32)
+            || !src_width.aligned(src_addr as u32)
+            || !dst_width.aligned(dst_addr as u32)
+        {
+            panic!("DMA address not aligned");
+        }
+
+        let ch_cr = r.chctrl(ch);
+
+        ch_cr.src_addr().write_value(src_addr as u32);
+        ch_cr.dst_addr().write_value(dst_addr as u32);
+        ch_cr.tran_size().modify(|w| size_in_bytes / src_width.bytes());
+        // TODO: LLPointer
+
+        ch_cr.chan_req_ctrl().write(|w| {
+            w.set_dstreqsel(mux_ch as u8);
+            w.set_srcreqsel(mux_ch as u8); // ? mux_ch or ch?
+        });
+
+        // TODO: handle SwapTable here
+
+        // clear transfer irq status (W1C)
+        r.inthalfsts().modify(|w| w.set_sts(ch, true));
+        r.inttcsts().modify(|w| w.set_sts(ch, true));
+        r.intabortsts().modify(|w| w.set_sts(ch, true));
+        r.interrsts().modify(|w| w.set_sts(ch, true));
+
+        ch_cr.ctrl().modify(|w| {});
+    }
+}

--- a/src/dma/dmamux.rs
+++ b/src/dma/dmamux.rs
@@ -2,12 +2,8 @@
 
 use crate::pac;
 
-pub(crate) struct DmamuxInfo {
-    pub(crate) num: usize,
-}
-
-pub(crate) fn configure_dmamux(info: &DmamuxInfo, request: u8) {
-    let ch_mux_regs = pac::DMAMUX.muxcfg(info.num);
+pub(crate) fn configure_dmamux(mux_num: usize, request: u8) {
+    let ch_mux_regs = pac::DMAMUX.muxcfg(mux_num);
     ch_mux_regs.write(|reg| {
         reg.set_enable(true);
         reg.set_source(request);

--- a/src/dma/mod.rs
+++ b/src/dma/mod.rs
@@ -13,6 +13,7 @@
 mod dmamux;
 pub(crate) use dmamux::*;
 use embassy_hal_internal::{impl_peripheral, Peripheral};
+pub(crate) mod dma;
 
 pub mod word;
 
@@ -30,6 +31,15 @@ pub(crate) struct ChannelInfo {
 pub(crate) enum DmaInfo {
     HDMA(pac::dma::Dma),
     XDMA(pac::dma::Dma),
+}
+
+impl DmaInfo {
+    pub(crate) fn regs(&self) -> &pac::dma::Dma {
+        match self {
+            DmaInfo::HDMA(dma) => dma,
+            DmaInfo::XDMA(dma) => dma,
+        }
+    }
 }
 
 /// DMA request type alias. (also known as DMA channel number)

--- a/src/dma/word.rs
+++ b/src/dma/word.rs
@@ -21,4 +21,14 @@ impl WordSize {
             Self::EightBytes => 8,
         }
     }
+
+    /// Check if the address is aligned for this word size.
+    pub fn aligned(&self, addr: u32) -> bool {
+        match self {
+            Self::OneByte => true,
+            Self::TwoBytes => addr % 2 == 0,
+            Self::FourBytes => addr % 4 == 0,
+            Self::EightBytes => addr % 8 == 0,
+        }
+    }
 }

--- a/src/i2c/mod.rs
+++ b/src/i2c/mod.rs
@@ -19,7 +19,7 @@ use crate::time::Hertz;
 const HPM_I2C_DRV_DEFAULT_TPM: i32 = 0;
 
 // family specific features
-#[cfg(any(hpm53, hpm68))]
+#[cfg(any(hpm53, hpm68, hpm6e))]
 const I2C_SOC_TRANSFER_COUNT_MAX: usize = 4096;
 #[cfg(any(hpm67, hpm62, hpm63, hpm64))]
 const I2C_SOC_TRANSFER_COUNT_MAX: usize = 256;
@@ -223,7 +223,6 @@ impl<'d, M: Mode> I2c<'d, M> {
             w.set_iicen(true);
             w.set_master(true);
         });
-
 
         if r.status().read().linescl() == false {
             defmt::info!("CLK is low, panic");

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -97,10 +97,18 @@ macro_rules! dma_trait {
     };
 }
 
+// Usage: impl TxDma for every DMA channel
+/* usage of dma_trait! macro
+impl<C: crate::dma::Channel> TxDma<crate::peripherals::I2C0> for C {
+    fn request(&self) -> crate::dma::Request {
+        todo!()
+    }
+}
+*/
 #[allow(unused)]
 macro_rules! dma_trait_impl {
-    (crate::$mod:ident::$trait:ident$(<$mode:ident>)?, $instance:ident, $channel:ident, $request:expr) => {
-        impl crate::$mod::$trait<crate::peripherals::$instance $(, crate::$mod::$mode)?> for crate::peripherals::$channel {
+    (crate::$mod:ident::$trait:ident$(<$mode:ident>)?, $instance:ident, $request:expr) => {
+        impl<C: crate::dma::Channel> crate::$mod::$trait<crate::peripherals::$instance $(, crate::$mod::$mode)?> for C {
             fn request(&self) -> crate::dma::Request {
                 $request
             }

--- a/src/patches.rs
+++ b/src/patches.rs
@@ -1,7 +1,7 @@
 //! Patches for the some of the peripherals
 
-#[cfg(hpm53)]
-mod hpm53 {
+#[cfg(any(hpm53, hpm6e))]
+mod power_domain_perih {
     use crate::peripherals;
     use crate::sysctl::ClockConfig;
     use crate::time::Hertz;

--- a/src/rt.rs
+++ b/src/rt.rs
@@ -79,4 +79,9 @@ unsafe fn __pre_init() {
         input = out(reg) _,
         a = out(reg) _,
     );
+
+    // enable mcycle
+    unsafe {
+        riscv::register::mcounteren::set_cy();
+    }
 }

--- a/src/sysctl/pll.rs
+++ b/src/sysctl/pll.rs
@@ -1,0 +1,31 @@
+use crate::time::Hertz;
+
+/// PLLv2 configuration
+#[derive(Clone, Copy)]
+pub struct Pll<D> {
+    pub freq_in: Hertz,
+    pub div: D,
+}
+
+impl<D> Pll<D> {
+    /// (mfi, mfn)
+    pub(crate) fn get_params(&self) -> Option<(u8, u32)> {
+        const PLL_XTAL_FREQ: u32 = 24000000;
+
+        const PLL_FREQ_MIN: u32 = PLL_XTAL_FREQ * 16; // min MFI, when MFN = 0
+        const PLL_FREQ_MAX: u32 = PLL_XTAL_FREQ * (42 + 1); // max MFI + MFN/MFD
+
+        const MFN_FACTOR: u32 = 10;
+
+        let f_vco = self.freq_in.0;
+
+        if f_vco < PLL_FREQ_MIN || f_vco > PLL_FREQ_MAX {
+            return None;
+        }
+
+        let mfi = f_vco / PLL_XTAL_FREQ;
+        let mfn = f_vco % PLL_XTAL_FREQ;
+
+        Some((mfi as u8, mfn * MFN_FACTOR))
+    }
+}

--- a/src/sysctl/v53.rs
+++ b/src/sysctl/v53.rs
@@ -1,0 +1,244 @@
+//! System control, clocks, group links.
+
+use core::ops;
+
+use super::{clock_and_to_group, Pll};
+use crate::pac;
+pub use crate::pac::sysctl::vals::{ClockMux, SubDiv as AHBDiv};
+use crate::pac::{PLLCTL, SYSCTL};
+use crate::time::Hertz;
+
+pub const CLK_32K: Hertz = Hertz(32_768);
+pub const CLK_24M: Hertz = Hertz(24_000_000);
+
+// default clock sources
+const PLL0CLK0: Hertz = Hertz(720_000_000);
+const PLL0CLK1: Hertz = Hertz(600_000_000);
+const PLL0CLK2: Hertz = Hertz(400_000_000);
+
+const PLL1CLK0: Hertz = Hertz(800_000_000);
+const PLL1CLK1: Hertz = Hertz(666_666_667);
+const PLL1CLK2: Hertz = Hertz(500_000_000);
+const PLL1CLK3: Hertz = Hertz(266_666_667);
+
+const CLK_HART0: Hertz = Hertz(720_000_000 / 2); // PLL0CLK0 / 2
+const CLK_AHB: Hertz = Hertz(720_000_000 / 2 / 2); // CLK_HART0 / 2
+
+const F_REF: Hertz = CLK_24M;
+
+/// The default system clock configuration
+pub(crate) static mut CLOCKS: Clocks = Clocks {
+    cpu0: CLK_HART0,
+    ahb: CLK_AHB,
+    pll0clk0: PLL0CLK0,
+    pll0clk1: PLL0CLK1,
+    pll0clk2: PLL0CLK2,
+    pll1clk0: PLL1CLK0,
+    pll1clk1: PLL1CLK1,
+    pll1clk2: PLL1CLK2,
+    pll1clk3: PLL1CLK3,
+};
+
+#[derive(Clone, Copy, Debug)]
+pub struct Clocks {
+    /// CPU0
+    pub cpu0: Hertz,
+    /// AHB clock: HDMA, HRAM, MOT, ACMP, GPIO, ADC/DAC
+    pub ahb: Hertz,
+
+    // System clock source
+    pub pll0clk0: Hertz,
+    pub pll0clk1: Hertz,
+    pub pll0clk2: Hertz,
+    pub pll1clk0: Hertz,
+    pub pll1clk1: Hertz,
+    pub pll1clk2: Hertz,
+    pub pll1clk3: Hertz,
+}
+
+impl Clocks {
+    pub fn of(&self, src: ClockMux) -> Hertz {
+        match src {
+            ClockMux::CLK_24M => CLK_24M,
+            ClockMux::PLL0CLK0 => self.pll0clk0,
+            ClockMux::PLL0CLK1 => self.pll0clk1,
+            ClockMux::PLL0CLK2 => self.pll0clk2,
+            ClockMux::PLL1CLK0 => self.pll1clk0,
+            ClockMux::PLL1CLK1 => self.pll1clk1,
+            ClockMux::PLL1CLK2 => self.pll1clk2,
+            ClockMux::PLL1CLK3 => self.pll1clk3,
+        }
+    }
+
+    pub fn get_freq(&self, cfg: &ClockConfig) -> Hertz {
+        let clock_in = self.of(cfg.src);
+        clock_in / (cfg.raw_div as u32 + 1)
+    }
+
+    pub fn get_clock_freq(&self, clock: usize) -> Hertz {
+        let r = SYSCTL.clock(clock).read();
+        let clock_in = self.of(r.mux());
+        clock_in / (r.div() + 1)
+    }
+}
+
+pub struct Config {
+    pub pll0: Option<Pll<(u8, u8, u8)>>,
+    // pub pll1: Option<Pll<(u8, u8, u8, u8)>>,
+    pub cpu0: ClockConfig,
+    pub ahb_div: AHBDiv,
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Config {
+            pll0: None,
+            // pll1: None,
+            cpu0: ClockConfig::new(ClockMux::PLL0CLK0, 2),
+            ahb_div: AHBDiv::DIV2,
+        }
+    }
+}
+
+#[derive(Clone, Copy)]
+pub struct ClockConfig {
+    pub src: ClockMux,
+    /// raw div, 0 to 255, mapping to div 1 to 256
+    pub raw_div: u8,
+}
+
+impl ClockConfig {
+    pub const fn new(src: ClockMux, div: u16) -> Self {
+        assert!(div <= 256 && div > 0, "div must be in range 1 to 256");
+        ClockConfig {
+            src,
+            raw_div: div as u8 - 1,
+        }
+    }
+}
+
+#[inline]
+fn output_freq_of_pll(pll: usize) -> u64 {
+    let fref = F_REF.0 as f64;
+    let mfd = 240_000_000.0; // default value
+
+    let mfi = PLLCTL.pll(pll).mfi().read().mfi() as f64;
+    let mfn = PLLCTL.pll(pll).mfn().read().mfn() as f64;
+
+    let fvco = fref * (mfi + mfn / mfd);
+
+    fvco as u64
+}
+
+pub(crate) unsafe fn init(config: Config) {
+    if SYSCTL.clock_cpu(0).read().mux() == ClockMux::CLK_24M {
+        // TODO, enable XTAL
+        // SYSCTL.global00().modify(|w| w.set_mux(0b11));
+    }
+
+    clock_and_to_group(pac::resources::CPU0, 0);
+    clock_and_to_group(pac::resources::AHB0, 0);
+    clock_and_to_group(pac::resources::LMM0, 0);
+    clock_and_to_group(pac::resources::MCT0, 0);
+    clock_and_to_group(pac::resources::ROM0, 0);
+    clock_and_to_group(pac::resources::TMR0, 0);
+    clock_and_to_group(pac::resources::TMR1, 0);
+    clock_and_to_group(pac::resources::I2C2, 0);
+    clock_and_to_group(pac::resources::SPI1, 0);
+    clock_and_to_group(pac::resources::URT0, 0);
+    clock_and_to_group(pac::resources::URT3, 0);
+
+    clock_and_to_group(pac::resources::WDG0, 0);
+    clock_and_to_group(pac::resources::WDG1, 0);
+    clock_and_to_group(pac::resources::MBX0, 0);
+    clock_and_to_group(pac::resources::TSNS, 0);
+    clock_and_to_group(pac::resources::CRC0, 0);
+    clock_and_to_group(pac::resources::ADC0, 0);
+    clock_and_to_group(pac::resources::ACMP, 0);
+    clock_and_to_group(pac::resources::KMAN, 0);
+    clock_and_to_group(pac::resources::GPIO, 0);
+    clock_and_to_group(pac::resources::HDMA, 0);
+    clock_and_to_group(pac::resources::XPI0, 0);
+    clock_and_to_group(pac::resources::USB0, 0);
+
+    // Connect Group0 to CPU0
+    SYSCTL.affiliate(0).set().write(|w| w.set_link(1 << 0));
+
+    // Bump up DCDC voltage to 1175mv (default is 1150)
+    pac::PCFG.dcdc_mode().modify(|w| w.set_volt(1175));
+
+    if let Some(pll) = config.pll0.as_ref() {
+        if let Some((mfi, mfn)) = pll.get_params() {
+            if PLLCTL.pll(0).mfi().read().mfi() == mfi {
+                PLLCTL.pll(0).mfi().modify(|w| {
+                    w.set_mfi(mfi - 1);
+                });
+            }
+
+            PLLCTL.pll(0).mfi().modify(|w| {
+                w.set_mfi(mfi);
+            });
+
+            // Default mfd is 240M
+            PLLCTL.pll(0).mfn().write(|w| w.set_mfn(mfn));
+
+            while PLLCTL.pll(0).mfi().read().busy() {}
+        }
+
+        let fvco = output_freq_of_pll(0);
+
+        // set postdiv
+        PLLCTL.pll(0).div(0).write(|w| {
+            w.set_div(pll.div.0);
+            w.set_enable(true);
+        });
+        PLLCTL.pll(0).div(1).write(|w| {
+            w.set_div(pll.div.1);
+            w.set_enable(true);
+        });
+        PLLCTL.pll(0).div(2).write(|w| {
+            w.set_div(pll.div.2);
+            w.set_enable(true);
+        });
+
+        while PLLCTL.pll(0).div(0).read().busy()
+            || PLLCTL.pll(0).div(1).read().busy()
+            || PLLCTL.pll(0).div(2).read().busy()
+        {}
+
+        let pll0clk0 = fvco * 5 / (PLLCTL.pll(0).div(0).read().div() as u64 + 5);
+        let pll0clk1 = fvco * 5 / (PLLCTL.pll(0).div(1).read().div() as u64 + 5);
+        let pll0clk2 = fvco * 5 / (PLLCTL.pll(0).div(2).read().div() as u64 + 5);
+
+        unsafe {
+            CLOCKS.pll0clk0 = Hertz(pll0clk0 as u32);
+            CLOCKS.pll0clk1 = Hertz(pll0clk1 as u32);
+            CLOCKS.pll0clk2 = Hertz(pll0clk2 as u32);
+        }
+    }
+
+    SYSCTL.clock_cpu(0).modify(|w| {
+        w.set_mux(config.cpu0.src);
+        w.set_div(config.cpu0.raw_div);
+        w.set_sub0_div(config.ahb_div);
+    });
+
+    while SYSCTL.clock_cpu(0).read().glb_busy() {}
+
+    let cpu0_clk = CLOCKS.get_freq(&config.cpu0);
+    let ahb_clk = cpu0_clk / config.ahb_div;
+
+    unsafe {
+        CLOCKS.cpu0 = cpu0_clk;
+        CLOCKS.ahb = ahb_clk;
+    }
+}
+
+impl ops::Div<AHBDiv> for Hertz {
+    type Output = Hertz;
+
+    /// raw bits 0 to 15 mapping to div 1 to div 16
+    fn div(self, rhs: AHBDiv) -> Hertz {
+        Hertz(self.0 / (rhs as u32 + 1))
+    }
+}

--- a/src/sysctl/v6e.rs
+++ b/src/sysctl/v6e.rs
@@ -1,0 +1,212 @@
+//! System control, clocks, group links.
+
+use super::{clock_and_to_group, Pll};
+use crate::pac;
+pub use crate::pac::sysctl::vals::ClockMux;
+use crate::pac::{PLLCTL, SYSCTL};
+use crate::time::Hertz;
+
+pub const CLK_32K: Hertz = Hertz(32_768);
+pub const CLK_24M: Hertz = Hertz(24_000_000);
+
+// default clock sources
+const PLL0CLK0: Hertz = Hertz(600_000_000);
+const PLL0CLK1: Hertz = Hertz(500_000_000);
+
+const PLL1CLK0: Hertz = Hertz(400_000_000);
+const PLL1CLK1: Hertz = Hertz(333_333_333);
+const PLL1CLK2: Hertz = Hertz(250_000_000);
+
+// PLL2: 722_534_400
+const PLL2CLK0: Hertz = Hertz(516_096_000); // 1.4
+const PLL2CLK1: Hertz = Hertz(451_584_000); // 1.6
+
+const CLK_CPU0: Hertz = Hertz(600_000_000); // PLL0CLK0
+const CLK_CPU1: Hertz = Hertz(600_000_000); // PLL0CLK0
+const CLK_AHB: Hertz = Hertz(400_000_000 / 2); // PLL1CLK0 / 2
+
+const F_REF: Hertz = CLK_24M;
+
+/// The default system clock configuration
+pub(crate) static mut CLOCKS: Clocks = Clocks {
+    cpu0: CLK_CPU0,
+    cpu1: CLK_CPU1,
+    ahb: CLK_AHB,
+    pll0clk0: PLL0CLK0,
+    pll0clk1: PLL0CLK1,
+    pll1clk0: PLL1CLK0,
+    pll1clk1: PLL1CLK1,
+    pll1clk2: PLL1CLK2,
+    pll2clk0: PLL2CLK0,
+    pll2clk1: PLL2CLK1,
+};
+
+#[derive(Clone, Copy, Debug)]
+pub struct Clocks {
+    pub cpu0: Hertz,
+    pub cpu1: Hertz,
+    /// AHB clock: HDMA, HRAM, MOT, ACMP, GPIO, ADC/DAC
+    pub ahb: Hertz,
+
+    // System clock source
+    pub pll0clk0: Hertz,
+    pub pll0clk1: Hertz,
+    pub pll1clk0: Hertz,
+    pub pll1clk1: Hertz,
+    pub pll1clk2: Hertz,
+    pub pll2clk0: Hertz,
+    pub pll2clk1: Hertz,
+}
+
+impl Clocks {
+    pub fn of(&self, src: ClockMux) -> Hertz {
+        match src {
+            ClockMux::CLK_24M => CLK_24M,
+            ClockMux::PLL0CLK0 => self.pll0clk0,
+            ClockMux::PLL0CLK1 => self.pll0clk1,
+            ClockMux::PLL1CLK0 => self.pll1clk0,
+            ClockMux::PLL1CLK1 => self.pll1clk1,
+            ClockMux::PLL1CLK2 => self.pll1clk2,
+            ClockMux::PLL2CLK0 => self.pll2clk0,
+            ClockMux::PLL2CLK1 => self.pll2clk1,
+        }
+    }
+
+    pub fn get_freq(&self, cfg: &ClockConfig) -> Hertz {
+        let clock_in = self.of(cfg.src);
+        clock_in / (cfg.raw_div as u32 + 1)
+    }
+
+    /// use `pac::clocks::` values as clock index
+    pub fn get_clock_freq(&self, clock: usize) -> Hertz {
+        let r = SYSCTL.clock(clock).read();
+        let clock_in = self.of(r.mux());
+        clock_in / (r.div() + 1)
+    }
+}
+
+pub struct Config {
+    pub pll0: Option<Pll<[u8; 2]>>,
+    pub pll1: Option<Pll<[u8; 3]>>,
+    pub pll2: Option<Pll<[u8; 2]>>,
+    pub cpu0: ClockConfig,
+    pub cpu1: ClockConfig,
+    pub ahb: ClockConfig,
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Config {
+            pll0: None,
+            pll1: None,
+            pll2: None,
+            cpu0: ClockConfig::new(ClockMux::PLL0CLK0, 1),
+            cpu1: ClockConfig::new(ClockMux::PLL0CLK0, 1),
+            ahb: ClockConfig::new(ClockMux::PLL1CLK0, 2),
+        }
+    }
+}
+
+#[derive(Clone, Copy)]
+pub struct ClockConfig {
+    pub src: ClockMux,
+    /// raw div, 0 to 255, mapping to div 1 to 256
+    pub raw_div: u8,
+}
+
+impl ClockConfig {
+    pub const fn new(src: ClockMux, div: u16) -> Self {
+        assert!(div <= 256 && div > 0, "div must be in range 1 to 256");
+        ClockConfig {
+            src,
+            raw_div: div as u8 - 1,
+        }
+    }
+}
+
+#[inline]
+fn output_freq_of_pll(pll: usize) -> u64 {
+    let fref = F_REF.0 as f64;
+    let mfd = 240_000_000.0; // default value
+
+    let mfi = PLLCTL.pll(pll).mfi().read().mfi() as f64;
+    let mfn = PLLCTL.pll(pll).mfn().read().mfn() as f64;
+
+    let fvco = fref * (mfi + mfn / mfd);
+
+    fvco as u64
+}
+
+pub(crate) unsafe fn init(config: Config) {
+    const PLLCTL_SOC_PLL_REFCLK_FREQ: u32 = 24 * 1_000_000;
+
+    if CLOCKS.get_clock_freq(pac::clocks::CPU0).0 == PLLCTL_SOC_PLL_REFCLK_FREQ {
+        // Configure the External OSC ramp-up time: ~9ms
+        let rc24m_cycles = 32 * 1000 * 9;
+        PLLCTL.xtal().modify(|w| w.set_ramp_time(rc24m_cycles));
+
+        // select clock setting preset1
+        SYSCTL.global00().modify(|w| w.set_mux(2));
+    }
+
+    clock_and_to_group(pac::resources::CPU0, 0);
+    clock_and_to_group(pac::resources::AHBP, 0);
+    clock_and_to_group(pac::resources::AXIC, 0);
+    clock_and_to_group(pac::resources::AXIN, 0);
+    clock_and_to_group(pac::resources::AXIS, 0);
+
+    clock_and_to_group(pac::resources::ROM0, 0);
+    clock_and_to_group(pac::resources::RAM0, 0);
+    clock_and_to_group(pac::resources::RAM1, 0);
+    clock_and_to_group(pac::resources::XPI0, 0);
+    clock_and_to_group(pac::resources::FEMC, 0);
+
+    clock_and_to_group(pac::resources::MCT0, 0);
+    clock_and_to_group(pac::resources::LMM0, 0);
+    clock_and_to_group(pac::resources::LMM1, 0);
+
+    clock_and_to_group(pac::resources::GPIO, 0);
+    clock_and_to_group(pac::resources::HDMA, 0);
+    clock_and_to_group(pac::resources::XDMA, 0);
+    clock_and_to_group(pac::resources::USB0, 0);
+
+    // Connect Group0 to CPU0
+    SYSCTL.affiliate(0).set().write(|w| w.set_link(1 << 0));
+
+    clock_and_to_group(pac::resources::CPU1, 1);
+    clock_and_to_group(pac::resources::MCT1, 1);
+
+    SYSCTL.affiliate(1).set().write(|w| w.set_link(1 << 1));
+
+    // Bump up DCDC voltage to 1175mv (default is 1150)
+    pac::PCFG.dcdc_mode().modify(|w| w.set_volt(1200));
+
+    // TODO: PLL setting
+    let pll2 = output_freq_of_pll(2);
+    defmt::debug!("PLL2: {}", pll2);
+
+    SYSCTL.clock(pac::clocks::CPU0).modify(|w| {
+        w.set_mux(config.cpu0.src);
+        w.set_div(config.cpu0.raw_div);
+    });
+    SYSCTL.clock(pac::clocks::CPU1).modify(|w| {
+        w.set_mux(config.cpu1.src);
+        w.set_div(config.cpu1.raw_div);
+    });
+    SYSCTL.clock(pac::clocks::AHB0).modify(|w| {
+        w.set_mux(config.ahb.src);
+        w.set_div(config.ahb.raw_div);
+    });
+
+    while SYSCTL.clock(0).read().glb_busy() {}
+
+    let cpu0_clk = CLOCKS.get_freq(&config.cpu0);
+    let cpu1_clk = CLOCKS.get_freq(&config.cpu1);
+    let ahb_clk = CLOCKS.get_freq(&config.ahb);
+
+    unsafe {
+        CLOCKS.cpu0 = cpu0_clk;
+        CLOCKS.cpu1 = cpu1_clk;
+        CLOCKS.ahb = ahb_clk;
+    }
+}


### PR DESCRIPTION
- HPM6E00 flash algorithm, in HPMicro.yaml
  - NOR FLASH CFG is from the hpm6e00evk board
  - Flash size detection is not used
- Add HPM6E sysctl int, split files. PLL is not added, since the default clock settings are OK
- Demo code for hpm6e00evk's RGB LEDs

## Additional non-HPM6E00 changes

- Refine DMA channel impl trait maco, avoid impl from every channel
- minor rt init enhancement from hpm_sdk logic
- clean up PLIC state when start
