### PR TITLE
Add DMAv2 implementation, Async UART support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 **/target
 trash/
 Cargo.lock
+*.bak

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 trash/
 Cargo.lock
 *.bak
+
+.vscode/

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,0 @@
-{
-    "rust-analyzer.check.allTargets": false,
-    "rust-analyzer.linkedProjects": [
-        "examples/hpm5300evk/Cargo.toml",
-        "examples/hpm6e00evk/Cargo.toml"
-    ]
-}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,8 @@ defmt = { version = "0.3.8", optional = true }
 embedded-io = "0.6.1"
 nb = "1.1.0"
 futures-util = { version = "0.3.30", optional = true, default-features = false }
+embedded-hal-nb = "1.0.0"
+embedded-io-async = "0.6.1"
 
 
 [build-dependencies]

--- a/README.md
+++ b/README.md
@@ -14,7 +14,11 @@ This crate is a working-in-progress and not ready for use.
   - [x] PLL setting
   - [x] GPIO, Flex, Input, Output, Async
   - [x] RTT support (defmt, defmt-rtt)
-  - [x] UART blocking TX, RX
+  - [x] DMA
+    - DMA v2
+  - [x] UART
+    - blocking driver
+    - async driver using DMA
   - [x] I2C blocking
   - [x] MBX, blocking and async
   - [x] FEMC
@@ -26,14 +30,14 @@ This crate is a working-in-progress and not ready for use.
   - [ ] hpm-riscv-rt for customized runtime (riscv-rt is not fit)
   - [ ] CPU1 support - how to?
 
-| MCU Family | Demo | PAC | SYSCTL | GPIO | UART | I2C | MBX | ADC | DMA | SPI |
-|------------|:----:|:---:|:------:|:----:|:----:|:---:|:---:|:---:|:---:|:---:|
-| HPM6700    |  ✓   |  ✓  |        |      |      |     |     |     |     |     |
-| HPM6300    |  ✓   |  ✓  |        |      |      |     |     |     |     |     |
-| HPM6200    |      |  ✓  |        |      |      |     |     |     |     |     |
-| HPM5300    |  ✓   |  ✓  |   ✓    |  ✓   |  ✓   |  ✓  |  ✓  |     |     |  ✓  |
-| HPM6800    |      |  ✓  |        |      |      |     |     |     |     |     |
-| HPM6E00    |  ✓   |  ✓  |   ✓    |  ✓   |  ✓   |  ?  |  ?  |     |     |  ?  |
+| MCU Family | Demo | PAC | SYSCTL | GPIO | UART | I2C | MBX | ADC | DMA | SPI | DMA |
+|------------|:----:|:---:|:------:|:----:|:----:|:---:|:---:|:---:|:---:|:---:|:---:|
+| HPM6700    |  ✓   |  ✓  |        |      |      |     |     |     |     |     |     |
+| HPM6300    |  ✓   |  ✓  |        |      |      |     |     |     |     |     |     |
+| HPM6200    |      |  ✓  |        |      |      |     |     |     |     |     |     |
+| HPM5300    |  ✓   |  ✓  |   ✓    |  ✓   |  ✓   |  ✓  |  ✓  |     |     |  ✓  |  ✓  |
+| HPM6800    |      |  ✓  |        |      |      |     |     |     |     |     |  ?  |
+| HPM6E00    |  ✓   |  ✓  |   ✓    |  ✓   |  ✓   |  ?  |  ?  |     |     |  ?  |  ?  |
 
 - ✓: Implemented
 - ?: Requires demo verification
@@ -74,6 +78,7 @@ The best reference is the examples in the `examples` directory and Github action
 - Choose one debugger:
   - OpenOCD: HPM's fork <https://github.com/hpmicro/riscv-openocd>
   - [probe-rs]: <https://github.com/probe-rs/probe-rs>
+    - The `HPMicro.yaml` flash algorithm is provided in top level of this repo
 
 #### Step 1. Prepare Rust Toolchain
 

--- a/README.md
+++ b/README.md
@@ -49,14 +49,6 @@ This crate is a working-in-progress and not ready for use.
 
 The best reference is the examples in the `examples` directory and Github actions workflow.
 
-To get it compile, you might need to use the [hpm-metapac] snapshot repo, or build from [hpm-data] yourself.
-
-Edit the `Cargo.toml` to use the git-based dependency:
-
-```toml
-hpm-metapac = { version = "0.0.3", git = "https://github.com/hpmicro-rs/hpm-metapac.git", tag="hpm-data-d9f90671e5b8ebd51c9565484919b4b880b6a23a" }
-```
-
 ### Requirements
 
 - A probe(debugger), optional if you are using official HPMicro's development board
@@ -73,18 +65,62 @@ hpm-metapac = { version = "0.0.3", git = "https://github.com/hpmicro-rs/hpm-meta
   - `rustup default nightly-2024-06-12` (locked because of bug [rust-embedded/riscv#196](https://github.com/rust-embedded/riscv/issues/196))
   - `rustup target add riscv32imafc-unknown-none-elf`
 
-### Run the examples
+### Guide
+
+#### Step 0. Prerequisites
+
+- Install Rust: <https://rustup.rs/>
+- Download HPM SDK: <https://github.com/hpmicro/hpm_sdk>
+- Choose one debugger:
+  - OpenOCD: HPM's fork <https://github.com/hpmicro/riscv-openocd>
+  - [probe-rs]: <https://github.com/probe-rs/probe-rs>
+
+#### Step 1. Prepare Rust Toolchain
+
+```bash
+rustup default nightly-2024-06-12
+rustup target add riscv32imafc-unknown-none-elf
+```
+
+#### Step 2. Prepare `metapac`
+
+Use the [hpm-metapac] snapshot repo or build from [hpm-data].
+
+Update `Cargo.toml` with the git-based dependency:
+
+```toml
+hpm-metapac = { version = "0.0.3", git = "https://github.com/hpmicro-rs/hpm-metapac.git", tag="hpm-data-d9f90671e5b8ebd51c9565484919b4b880b6a23a" }
+```
+
+#### Step 3. Run Examples
+
+1. Edit `examples/YOUR_BOARD/.cargo/config.toml` to set the correct flash/run command for your probe.
+
+2. (Optional) Edit and run `run-openocd.sh` if using OpenOCD.
+
+3. Connect your probe to the target board.
+
+4. Run an example:
 
 ```bash
 cd examples/hpm5300evk
 cargo run --release --bin blinky
 ```
 
+## License
+
+Embassy is licensed under either of
+
+- Apache License, Version 2.0 ([LICENSE-APACHE](LICENSE-APACHE) or
+  <http://www.apache.org/licenses/LICENSE-2.0>)
+- MIT license ([LICENSE-MIT](LICENSE-MIT) or <http://opensource.org/licenses/MIT>)
+
+at your option.
+
 ## Contributing
 
 This crate is under active development. Before starting your work, it's better to create a "Work in Progress" (WIP) pull request describing your work to avoid conflicts.
 
 [hpm-data]: https://github.com/andelf/hpm-data
-[probe-rs]: https://github.com/probe-rs/probe-rs
 [hpm-metapac]: https://github.com/hpmicro-rs/hpm-metapac
 [HPM OpenOCD]: https://github.com/hpmicro/riscv-openocd

--- a/build.rs
+++ b/build.rs
@@ -10,6 +10,84 @@ use hpm_metapac::metadata::METADATA;
 use proc_macro2::TokenStream;
 use quote::{format_ident, quote};
 
+// HPM_SOC_IP_FEATURE
+fn get_ip_features(chip_family: &str) -> &[&str] {
+    match chip_family {
+        "hpm67" | "hpm64" => &["ADC16_HAS_TEMPSNS"],
+        "hpm63" => &["PWM_COUNTER_RESET"],
+        "hpm62" => &["UART_RX_IDLE_DETECT", "PWM_COUNTER_RESET", "PWM_HRPWM"],
+        "hpm53" => &[
+            "GPTMR_MONITOR",
+            "GPTMR_OP_MODE",
+            "UART_RX_IDLE_DETECT",
+            "UART_FCRR",
+            "UART_RX_EN",
+            "UART_E00018_FIX",
+            "UART_9BIT_MODE",
+            "UART_ADDR_MATCH",
+            "UART_TRIG_MODE",
+            "UART_FINE_FIFO_THRLD",
+            "UART_IIR2",
+            "I2C_SUPPORT_RESET",
+            "SPI_NEW_TRANS_COUNT",
+            "SPI_CS_SELECT",
+            "SPI_SUPPORT_DIRECTIO",
+            "PWM_COUNTER_RESET",
+            "ADC16_HAS_MOT_EN",
+        ],
+        "hpm68" => &[
+            "UART_RX_IDLE_DETECT",
+            "UART_FCRR",
+            "UART_RX_EN",
+            "I2C_SUPPORT_RESET",
+            "SPI_NEW_TRANS_COUNT",
+            "SPI_CS_SELECT",
+            "SPI_SUPPORT_DIRECTIO",
+            "GPTMR_MONITOR",
+            "GPTMR_OP_MODE",
+            "DAO_DATA_FORMAT_CONFIG",
+            "CAM_INV_DEN",
+        ],
+        "hpm6e" => &[
+            "GPTMR_MONITOR",
+            "GPTMR_OP_MODE",
+            "GPTMR_CNT_MODE",
+            "UART_RX_IDLE_DETECT",
+            "UART_FCRR",
+            "UART_RX_EN",
+            "UART_E00018_FIX",
+            "UART_9BIT_MODE",
+            "UART_ADDR_MATCH",
+            "UART_TRIG_MODE",
+            "UART_FINE_FIFO_THRLD",
+            "UART_IIR2",
+            "I2C_SUPPORT_RESET",
+            "SPI_NEW_TRANS_COUNT",
+            "SPI_CS_SELECT",
+            "SPI_SUPPORT_DIRECTIO",
+            "DMAV2_BURST_IN_FIXED_TRANS",
+            "DMAV2_BYTE_ORDER_SWAP",
+            "ADC16_HAS_MOT_EN",
+            "DAO_DATA_FORMAT_CONFIG",
+            "QEIV2_ONESHOT_MODE",
+            "QEIV2_SW_RESTART_TRG",
+            "QEIV2_TIMESTAMP",
+            "QEIV2_ADC_THRESHOLD",
+            "RDC_IIR",
+            "SEI_RX_LATCH_FEATURE",
+            "SEI_ASYNCHRONOUS_MODE_V2",
+            "SEI_TIMEOUT_REWIND_FEATURE",
+            "SEI_HAVE_DAT10_31",
+            "SEI_HAVE_INTR64_255",
+            "SEI_HAVE_CTRL2_12",
+            "SEI_HAVE_PTCD",
+            "ENET_HAS_MII_MODE",
+            "FFA_FP32",
+        ],
+        _ => panic!("Unknown chip family: {}", chip_family),
+    }
+}
+
 fn main() {
     let mut cfgs = CfgSet::new();
 
@@ -30,7 +108,12 @@ fn main() {
 
     // hpm53, hpm67, etc
     let family_name = chip_name[0..5].to_ascii_lowercase();
-    cfgs.enable(family_name);
+    cfgs.enable(&family_name);
+
+    // IP feature gates, usesage: #[cfg(ip_feature_adc16_has_tempsns)]
+    for feature in get_ip_features(&family_name) {
+        cfgs.enable(&format!("ip_feature_{}", feature.to_ascii_lowercase()));
+    }
 
     for p in METADATA.peripherals {
         if let Some(r) = &p.registers {

--- a/build.rs
+++ b/build.rs
@@ -344,8 +344,9 @@ fn main() {
 
             quote! {
                 #[cfg(feature = "rt")]
+                #[allow(non_snake_case)]
                 #[no_mangle]
-                unsafe fn #irq() {
+                unsafe extern "riscv-interrupt-m" fn #irq() {
                     <crate::peripherals::#peri_name as crate::dma::ControllerInterrupt>::on_irq();
                 }
             }

--- a/examples/hpm5300evk/Cargo.toml
+++ b/examples/hpm5300evk/Cargo.toml
@@ -4,7 +4,8 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-hpm-hal = { path = "../..", features = ["rt", "embassy", "hpm5301"] }
+# hpm5301 is a subset of hpm5361, either is ok if you have the 5301 board.
+hpm-hal = { path = "../..", features = ["rt", "embassy", "hpm5361"] }
 
 panic-halt = "0.2.0"
 riscv-rt = "0.12.2"

--- a/examples/hpm5300evk/src/bin/embassy_blinky.rs
+++ b/examples/hpm5300evk/src/bin/embassy_blinky.rs
@@ -11,7 +11,7 @@ use {defmt_rtt as _, hpm_hal as hal};
 
 const BOARD_NAME: &str = "HPM5300EVK";
 
-#[embassy_executor::task]
+#[embassy_executor::task(pool_size = 2)]
 async fn blink(pin: AnyPin) {
     let mut led = Flex::new(pin);
     led.set_as_output(Default::default());
@@ -45,6 +45,7 @@ async fn main(spawner: Spawner) -> ! {
     //println!("mie: {:?}", mie);
 
     spawner.spawn(blink(p.PA23.degrade())).unwrap();
+    spawner.spawn(blink(p.PA10.degrade())).unwrap();
 
     loop {
         Timer::after_millis(1000).await;

--- a/examples/hpm5300evk/src/bin/raw_pwm.rs
+++ b/examples/hpm5300evk/src/bin/raw_pwm.rs
@@ -1,0 +1,133 @@
+#![no_main]
+#![no_std]
+#![feature(type_alias_impl_trait)]
+
+use defmt::println;
+use embassy_time::Delay;
+use embedded_hal::delay::DelayNs;
+use embedded_io::Write as _;
+use hal::pac;
+use hpm_hal::gpio::Output;
+use hpm_hal::mode::Blocking;
+use hpm_hal::pac::{iomux, pins};
+use {defmt_rtt as _, hpm_hal as hal};
+
+const BOARD_NAME: &str = "HPM5300EVK";
+const BANNER: &str = include_str!("./BANNER");
+
+macro_rules! println {
+    ($($arg:tt)*) => {
+        let _ = writeln!(unsafe {UART.as_mut().unwrap()}, $($arg)*);
+    };
+}
+
+static mut UART: Option<hal::uart::Uart<'static, Blocking>> = None;
+
+#[hal::entry]
+fn main() -> ! {
+    let mut config = hal::Config::default();
+    {
+        // MOT subsystem is using AHB
+        config.sysctl.ahb_div = hal::sysctl::AHBDiv::DIV2;
+    }
+    let p = hal::init(config);
+    // let button = Input::new(p.PA03, Pull::Down); // hpm5300evklite, BOOT1_KEY
+    let uart = hal::uart::Uart::new_blocking(p.UART0, p.PA01, p.PA00, Default::default()).unwrap();
+    unsafe {
+        UART = Some(uart);
+    }
+
+    let mut delay = Delay; // since embassy is inited, blocking Delay is usable
+
+    println!("{}", BANNER);
+    println!("{} init OK!", BOARD_NAME);
+
+    println!("Clock summary:");
+    println!("  CPU0:\t{}Hz", hal::sysctl::clocks().cpu0.0);
+    println!("  AHB:\t{}Hz", hal::sysctl::clocks().ahb.0);
+    println!(
+        "  XPI0:\t{}Hz",
+        hal::sysctl::clocks().get_clock_freq(hal::pac::clocks::XPI0).0
+    );
+    println!(
+        "  MTMR:\t{}Hz",
+        hal::sysctl::clocks().get_clock_freq(pac::clocks::MCT0).0
+    );
+
+    println!("==============================");
+
+    println!("Hello, world!");
+
+    // PWM1_P_7
+    // Close LED
+    let _led = Output::new(p.PA23, hal::gpio::Level::High, Default::default()); // active low
+
+    pac::IOC
+        .pad(pins::PA23)
+        .func_ctl()
+        .modify(|w| w.set_alt_select(iomux::IOC_PA23_FUNC_CTL_PWM1_P_7));
+
+    // must add to group
+    hal::sysctl::clock_add_to_group(pac::resources::MOT0, 0);
+
+    let ch7 = 7;
+    pac::PWM1.pwmcfg(ch7).modify(|w| {
+        w.set_oen(true);
+        w.set_pair(false);
+    });
+
+    pac::PWM1.sta().modify(|w| {
+        w.set_sta(0);
+        w.set_xsta(0);
+    });
+    pac::PWM1.rld().modify(|w| {
+        w.set_rld(0xffff);
+        w.set_xrld(0);
+    });
+
+    pac::PWM1.chcfg(ch7).modify(|w| {
+        w.set_cmpselbeg(7);
+        w.set_cmpselend(7);
+        w.set_outpol(false); // polarity
+    });
+
+    pac::PWM1.cmpcfg(7).modify(|w| {
+        w.set_cmpmode(false);
+        w.set_cmpshdwupt(0b01); // real-time shadow
+    }); // output
+
+    pac::PWM1.cmp(7).modify(|w| {
+        w.set_cmp(0xff); // half
+        w.set_xcmp(0);
+    });
+
+    //    pac::PWM1.shlk().modify(|w| w.set_)
+    // shadow latch
+    pac::PWM1.shcr().modify(|w| w.set_cntshdwupt(0b01)); // real-time shadow
+
+    pac::PWM1.gcr().modify(|w| {
+        w.set_cen(true);
+    });
+
+    loop {
+        for i in (0..0xffff).step_by(100) {
+            pac::PWM1.cmp(7).modify(|w| {
+                w.set_cmp(i);
+            });
+            delay.delay_ms(1);
+        }
+        for i in (0..0xffff).step_by(100).rev() {
+            pac::PWM1.cmp(7).modify(|w| {
+                w.set_cmp(i);
+            });
+            delay.delay_ms(1);
+        }
+    }
+}
+
+#[panic_handler]
+fn panic(info: &core::panic::PanicInfo) -> ! {
+    println!("\n\n\nPANIC:\n{}", info);
+
+    loop {}
+}

--- a/examples/hpm5300evk/src/bin/raw_pwm.rs
+++ b/examples/hpm5300evk/src/bin/raw_pwm.rs
@@ -9,6 +9,7 @@ use embedded_io::Write as _;
 use hal::pac;
 use hpm_hal::gpio::Output;
 use hpm_hal::mode::Blocking;
+use hpm_hal::pac::pwm::vals;
 use hpm_hal::pac::{iomux, pins};
 use {defmt_rtt as _, hpm_hal as hal};
 
@@ -93,7 +94,7 @@ fn main() -> ! {
 
     pac::PWM1.cmpcfg(7).modify(|w| {
         w.set_cmpmode(false);
-        w.set_cmpshdwupt(0b01); // real-time shadow
+        w.set_cmpshdwupt(vals::ShadowUpdateTrigger::ON_MODIFY);
     }); // output
 
     pac::PWM1.cmp(7).modify(|w| {
@@ -103,7 +104,9 @@ fn main() -> ! {
 
     //    pac::PWM1.shlk().modify(|w| w.set_)
     // shadow latch
-    pac::PWM1.shcr().modify(|w| w.set_cntshdwupt(0b01)); // real-time shadow
+    pac::PWM1
+        .shcr()
+        .modify(|w| w.set_cntshdwupt(vals::ShadowUpdateTrigger::ON_MODIFY));
 
     pac::PWM1.gcr().modify(|w| {
         w.set_cen(true);

--- a/examples/hpm5300evk/src/bin/uart_async.rs
+++ b/examples/hpm5300evk/src/bin/uart_async.rs
@@ -1,0 +1,96 @@
+#![no_main]
+#![no_std]
+#![feature(type_alias_impl_trait)]
+#![feature(abi_riscv_interrupt)]
+
+use embassy_executor::Spawner;
+use embassy_time::Timer;
+use hal::gpio::{AnyPin, Flex, Pin};
+use hpm_hal::time::Hertz;
+use hpm_hal::{bind_interrupts, peripherals};
+use {defmt_rtt as _, hpm_hal as hal};
+
+bind_interrupts!(struct Irqs {
+    UART0 => hal::uart::InterruptHandler<peripherals::UART0>;
+});
+
+const BANNER: &str = include_str!("./BANNER");
+
+#[embassy_executor::task(pool_size = 2)]
+async fn blink(pin: AnyPin) {
+    let mut led = Flex::new(pin);
+    led.set_as_output(Default::default());
+    led.set_high();
+
+    loop {
+        led.toggle();
+
+        Timer::after_millis(500).await;
+    }
+}
+
+#[embassy_executor::main(entry = "hpm_hal::entry")]
+async fn main(spawner: Spawner) -> ! {
+    let mut config = hal::Config::default();
+    {
+        use hal::sysctl::*;
+        config.sysctl.pll0 = Some(Pll {
+            div: (0, 1, 3),
+            freq_in: Hertz::mhz(960),
+        });
+        config.sysctl.cpu0 = ClockConfig::new(ClockMux::PLL0CLK0, 2);
+        config.sysctl.ahb_div = AHBDiv::DIV3;
+    }
+
+    let p = hal::init(config);
+
+    spawner.spawn(blink(p.PA23.degrade())).unwrap();
+    spawner.spawn(blink(p.PA10.degrade())).unwrap();
+
+    // let button = Input::new(p.PA03, Pull::Down); // hpm5300evklite, BOOT1_KEY
+    let mut uart = hal::uart::Uart::new(
+        p.UART0,
+        p.PA01,
+        p.PA00,
+        Irqs,
+        p.HDMA_CH1,
+        p.HDMA_CH0,
+        Default::default(),
+    )
+    .unwrap();
+
+    defmt::info!("Loop");
+
+    uart.write(BANNER.as_bytes()).await.unwrap();
+    uart.write(b"Hello Async World!\r\n").await.unwrap();
+    uart.write(b"Type something: ").await.unwrap();
+
+    let mut buf = [0u8; 256];
+    loop {
+        let n = uart.read_until_idle(&mut buf).await.unwrap();
+        for i in 0..n {
+            if buf[i] == b'\r' {
+                buf[i] = b'\n';
+            }
+        }
+
+        let s = core::str::from_utf8(&buf[..n]).unwrap();
+
+        uart.write(s.as_bytes()).await.unwrap();
+
+        defmt::info!("read => {:?}", s);
+    }
+}
+
+#[panic_handler]
+fn panic(info: &core::panic::PanicInfo) -> ! {
+    let mut err = heapless::String::<1024>::new();
+
+    use core::fmt::Write as _;
+
+    write!(err, "panic: {}", info).ok();
+
+    defmt::info!("{}", err.as_str());
+
+    loop {}
+}

--- a/src/dma/dmamux.rs
+++ b/src/dma/dmamux.rs
@@ -6,6 +6,6 @@ pub(crate) fn configure_dmamux(mux_num: usize, request: u8) {
     let ch_mux_regs = pac::DMAMUX.muxcfg(mux_num);
     ch_mux_regs.write(|reg| {
         reg.set_enable(true);
-        reg.set_source(request);
+        reg.set_source(request); // peripheral request number
     });
 }

--- a/src/dma/mod.rs
+++ b/src/dma/mod.rs
@@ -13,7 +13,7 @@
 mod dmamux;
 pub(crate) use dmamux::*;
 use embassy_hal_internal::{impl_peripheral, Peripheral};
-pub(crate) mod dma;
+pub(crate) mod v2;
 
 pub mod word;
 

--- a/src/dma/mod.rs
+++ b/src/dma/mod.rs
@@ -13,11 +13,19 @@
 mod dmamux;
 pub(crate) use dmamux::*;
 use embassy_hal_internal::{impl_peripheral, Peripheral};
+use v2::ChannelState;
 pub(crate) mod v2;
 
 pub mod word;
 
 use crate::{interrupt, pac};
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+enum Dir {
+    MemoryToPeripheral,
+    PeripheralToMemory,
+}
 
 pub(crate) struct ChannelInfo {
     pub(crate) dma: DmaInfo,
@@ -82,6 +90,9 @@ impl SealedChannel for AnyChannel {
     }
 }
 impl Channel for AnyChannel {}
+
+const CHANNEL_COUNT: usize = crate::_generated::DMA_CHANNELS.len();
+static STATE: [ChannelState; CHANNEL_COUNT] = [ChannelState::NEW; CHANNEL_COUNT];
 
 macro_rules! dma_channel_impl {
     ($channel_peri:ident, $index:expr) => {

--- a/src/dma/mod.rs
+++ b/src/dma/mod.rs
@@ -43,6 +43,7 @@ pub(crate) struct ChannelInfo {
 #[derive(Clone, Copy)]
 pub(crate) enum DmaInfo {
     HDMA(pac::dma::Dma),
+    #[allow(unused)]
     XDMA(pac::dma::Dma),
 }
 

--- a/src/dma/mod.rs
+++ b/src/dma/mod.rs
@@ -12,11 +12,16 @@
 
 mod dmamux;
 use embassy_hal_internal::{impl_peripheral, Peripheral};
-use v2::ChannelState;
+
+#[cfg(any(hpm53, hpm68, hpm6e))]
 pub(crate) mod v2;
+#[cfg(any(hpm53, hpm68, hpm6e))]
 pub use v2::*;
 
 pub mod word;
+
+mod util;
+pub(crate) use util::*;
 
 use crate::pac;
 

--- a/src/dma/util.rs
+++ b/src/dma/util.rs
@@ -1,0 +1,61 @@
+use embassy_hal_internal::PeripheralRef;
+
+use super::word::Word;
+use super::{AnyChannel, Request, Transfer, TransferOptions};
+
+/// Convenience wrapper, contains a channel and a request number.
+///
+/// Commonly used in peripheral drivers that own DMA channels.
+pub(crate) struct ChannelAndRequest<'d> {
+    pub channel: PeripheralRef<'d, AnyChannel>,
+    pub request: Request,
+}
+
+impl<'d> ChannelAndRequest<'d> {
+    pub unsafe fn read<'a, W: Word>(
+        &'a mut self,
+        peri_addr: *mut W,
+        buf: &'a mut [W],
+        options: TransferOptions,
+    ) -> Transfer<'a> {
+        Transfer::new_read(&mut self.channel, self.request, peri_addr, buf, options)
+    }
+
+    pub unsafe fn read_raw<'a, W: Word>(
+        &'a mut self,
+        peri_addr: *mut W,
+        buf: *mut [W],
+        options: TransferOptions,
+    ) -> Transfer<'a> {
+        Transfer::new_read_raw(&mut self.channel, self.request, peri_addr, buf, options)
+    }
+
+    pub unsafe fn write<'a, W: Word>(
+        &'a mut self,
+        buf: &'a [W],
+        peri_addr: *mut W,
+        options: TransferOptions,
+    ) -> Transfer<'a> {
+        Transfer::new_write(&mut self.channel, self.request, buf, peri_addr, options)
+    }
+
+    pub unsafe fn write_raw<'a, W: Word>(
+        &'a mut self,
+        buf: *const [W],
+        peri_addr: *mut W,
+        options: TransferOptions,
+    ) -> Transfer<'a> {
+        Transfer::new_write_raw(&mut self.channel, self.request, buf, peri_addr, options)
+    }
+
+    #[allow(dead_code)]
+    pub unsafe fn write_repeated<'a, W: Word>(
+        &'a mut self,
+        repeated: &'a W,
+        count: usize,
+        peri_addr: *mut W,
+        options: TransferOptions,
+    ) -> Transfer<'a> {
+        Transfer::new_write_repeated(&mut self.channel, self.request, repeated, count, peri_addr, options)
+    }
+}

--- a/src/dma/v2.rs
+++ b/src/dma/v2.rs
@@ -1,9 +1,9 @@
 //! DMA v2
 //!
 //! hpm53, hpm68, hpm6e
+#![allow(unused)]
 
 use core::future::Future;
-use core::num;
 use core::pin::Pin;
 use core::sync::atomic::{fence, AtomicUsize, Ordering};
 use core::task::{Context, Poll};

--- a/src/dma/word.rs
+++ b/src/dma/word.rs
@@ -1,5 +1,7 @@
 //! DMA word sizes
 
+use hpm_metapac::dma::vals;
+
 use crate::pac;
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
@@ -19,6 +21,15 @@ impl WordSize {
             Self::TwoBytes => 2,
             Self::FourBytes => 4,
             Self::EightBytes => 8,
+        }
+    }
+
+    pub(crate) fn width(&self) -> vals::Width {
+        match self {
+            Self::OneByte => vals::Width::BYTE,
+            Self::TwoBytes => vals::Width::HALF_WORD,
+            Self::FourBytes => vals::Width::WORD,
+            Self::EightBytes => vals::Width::DOUBLE_WORD,
         }
     }
 

--- a/src/dma/word.rs
+++ b/src/dma/word.rs
@@ -2,8 +2,6 @@
 
 use hpm_metapac::dma::vals;
 
-use crate::pac;
-
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum WordSize {

--- a/src/embassy/time_driver_mchtmr.rs
+++ b/src/embassy/time_driver_mchtmr.rs
@@ -63,6 +63,7 @@ impl MachineTimerDriver {
         self.period.store(cnt_per_tick as u32, Ordering::Relaxed);
 
         // make sure mchtmr will not be gated on "wfi"
+        // Design consideration: use WAIT is also useful to enter low-power mode
         SYSCTL.cpu(0).lp().modify(|w| w.set_mode(vals::LpMode::RUN));
         // 4 * 32 = 128 bits
         // enable wake up from all interrupts

--- a/src/femc.rs
+++ b/src/femc.rs
@@ -354,9 +354,10 @@ where
             r.dlycfg().modify(|w| w.set_oe(true));
         }
 
+        // NOTE: In hpm_sdk, the following is used:
+        // r.datsz().write(|w| w.0 = (config.cmd_data_width as u32) & 0x3);
+        // `0x3` is used to mask the value, but it is not necessary, as both 0b100 and 0b000 are valid values.
         r.datsz().write(|w| w.set_datsz(config.cmd_data_width));
-        // SDK-BUG: what's the meaning of 0x3 as mask?
-        // r.datsz().write(|w| w.0 = (config.cmd_data_width as u32) & 0x3); //????
         r.bytemsk().write(|w| w.0 = 0);
 
         self.issue_ip_cmd(config.base_address, SdramCmd::PRECHARGE_ALL, 0)?;

--- a/src/gpio/input_future.rs
+++ b/src/gpio/input_future.rs
@@ -6,6 +6,7 @@ use embassy_hal_internal::{Peripheral, PeripheralRef};
 use embassy_sync::waitqueue::AtomicWaker;
 
 use super::{AnyPin, Flex, Input, Pin as GpioPin, SealedPin};
+use crate::internal::BitIter;
 use crate::interrupt::InterruptExt;
 use crate::{interrupt, pac};
 
@@ -59,22 +60,6 @@ unsafe fn on_interrupt(port: usize) {
         pac::GPIO0.if_(port).value().write(|w| w.set_irq_flag(1 << pin)); // W1C
         pac::GPIO0.ie(port).clear().write(|w| w.set_irq_en(1 << pin));
         PORT_WAKERS[pin as usize].wake();
-    }
-}
-
-struct BitIter(u32);
-
-impl Iterator for BitIter {
-    type Item = u32;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        match self.0.trailing_zeros() {
-            32 => None,
-            b => {
-                self.0 &= !(1 << b);
-                Some(b)
-            }
-        }
     }
 }
 

--- a/src/gpio/mod.rs
+++ b/src/gpio/mod.rs
@@ -483,6 +483,11 @@ pub(crate) trait SealedPin: Sized {
     fn set_as_alt(&self, alt_num: u8) {
         self.ioc_pad().func_ctl().modify(|w| w.set_alt_select(alt_num));
     }
+
+    #[inline]
+    fn set_as_default(&self) {
+        self.ioc_pad().func_ctl().write(|w| w.0 = 0);
+    }
 }
 
 #[allow(private_bounds)]

--- a/src/internal/mod.rs
+++ b/src/internal/mod.rs
@@ -1,1 +1,18 @@
 pub mod interrupt;
+
+// used by GPIO interrupt handlers, and DMA controller
+pub(crate) struct BitIter(pub u32);
+
+impl Iterator for BitIter {
+    type Item = u32;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match self.0.trailing_zeros() {
+            32 => None,
+            b => {
+                self.0 &= !(1 << b);
+                Some(b)
+            }
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -152,6 +152,12 @@ pub fn init(config: Config) -> Peripherals {
         gpio::input_future::init_gpio0_irq();
     }
 
+    unsafe {
+        critical_section::with(|cs| {
+            dma::init(cs);
+        });
+    }
+
     #[cfg(feature = "embassy")]
     embassy::init();
 

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -136,3 +136,14 @@ macro_rules! dma_trait_impl {
         }
     };
 }
+
+macro_rules! new_dma {
+    ($name:ident) => {{
+        let dma = $name.into_ref();
+        let request = dma.request();
+        Some(crate::dma::ChannelAndRequest {
+            channel: dma.map_into(),
+            request,
+        })
+    }};
+}

--- a/src/spi/mod.rs
+++ b/src/spi/mod.rs
@@ -263,6 +263,7 @@ impl<'d> Spi<'d, Blocking> {
         )
     }
 
+    /// Create a new blocking SPI driver, in TX-only mode (only MOSI pin, no MISO).
     pub fn new_blocking_txonly<T: Instance>(
         peri: impl Peripheral<P = T> + 'd,
         sclk: impl Peripheral<P = impl SclkPin<T>> + 'd,
@@ -288,6 +289,21 @@ impl<'d> Spi<'d, Blocking> {
             None,
             config,
         )
+    }
+
+    /// Create a new SPI driver, in TX-only mode, without SCK pin.
+    pub fn new_blocking_txonly_nosck<T: Instance>(
+        peri: impl Peripheral<P = T> + 'd,
+        mosi: impl Peripheral<P = impl MosiPin<T>> + 'd,
+        config: Config,
+    ) -> Self {
+        into_ref!(mosi);
+
+        T::add_resource_group(0);
+
+        mosi.set_as_alt(mosi.alt_num());
+
+        Self::new_inner(peri, None, Some(mosi.map_into()), None, None, None, config)
     }
 
     pub fn new_blocking_quad<T: Instance>(

--- a/src/sysctl/mod.rs
+++ b/src/sysctl/mod.rs
@@ -22,7 +22,7 @@ pub fn clocks() -> &'static Clocks {
 }
 
 /// Add clock resource to a resource group
-pub fn clock_and_to_group(resource: usize, group: usize) {
+pub fn clock_add_to_group(resource: usize, group: usize) {
     const RESOURCE_START: usize = 256;
     if resource < RESOURCE_START {
         return;
@@ -53,7 +53,7 @@ pub(crate) trait SealedClockPeripheral {
             return;
         }
 
-        clock_and_to_group(Self::SYSCTL_RESOURCE, group);
+        clock_add_to_group(Self::SYSCTL_RESOURCE, group);
     }
 
     fn set_clock(cfg: ClockConfig) {

--- a/src/sysctl/v53.rs
+++ b/src/sysctl/v53.rs
@@ -40,6 +40,7 @@ pub(crate) static mut CLOCKS: Clocks = Clocks {
 };
 
 #[derive(Clone, Copy, Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct Clocks {
     /// CPU0
     pub cpu0: Hertz,

--- a/src/sysctl/v53.rs
+++ b/src/sysctl/v53.rs
@@ -2,7 +2,7 @@
 
 use core::ops;
 
-use super::{clock_and_to_group, Pll};
+use super::{clock_add_to_group, Pll};
 use crate::pac;
 pub use crate::pac::sysctl::vals::{ClockMux, SubDiv as AHBDiv};
 use crate::pac::{PLLCTL, SYSCTL};
@@ -136,30 +136,30 @@ pub(crate) unsafe fn init(config: Config) {
         // SYSCTL.global00().modify(|w| w.set_mux(0b11));
     }
 
-    clock_and_to_group(pac::resources::CPU0, 0);
-    clock_and_to_group(pac::resources::AHB0, 0);
-    clock_and_to_group(pac::resources::LMM0, 0);
-    clock_and_to_group(pac::resources::MCT0, 0);
-    clock_and_to_group(pac::resources::ROM0, 0);
-    clock_and_to_group(pac::resources::TMR0, 0);
-    clock_and_to_group(pac::resources::TMR1, 0);
-    clock_and_to_group(pac::resources::I2C2, 0);
-    clock_and_to_group(pac::resources::SPI1, 0);
-    clock_and_to_group(pac::resources::URT0, 0);
-    clock_and_to_group(pac::resources::URT3, 0);
+    clock_add_to_group(pac::resources::CPU0, 0);
+    clock_add_to_group(pac::resources::AHB0, 0);
+    clock_add_to_group(pac::resources::LMM0, 0);
+    clock_add_to_group(pac::resources::MCT0, 0);
+    clock_add_to_group(pac::resources::ROM0, 0);
+    clock_add_to_group(pac::resources::TMR0, 0);
+    clock_add_to_group(pac::resources::TMR1, 0);
+    clock_add_to_group(pac::resources::I2C2, 0);
+    clock_add_to_group(pac::resources::SPI1, 0);
+    clock_add_to_group(pac::resources::URT0, 0);
+    clock_add_to_group(pac::resources::URT3, 0);
 
-    clock_and_to_group(pac::resources::WDG0, 0);
-    clock_and_to_group(pac::resources::WDG1, 0);
-    clock_and_to_group(pac::resources::MBX0, 0);
-    clock_and_to_group(pac::resources::TSNS, 0);
-    clock_and_to_group(pac::resources::CRC0, 0);
-    clock_and_to_group(pac::resources::ADC0, 0);
-    clock_and_to_group(pac::resources::ACMP, 0);
-    clock_and_to_group(pac::resources::KMAN, 0);
-    clock_and_to_group(pac::resources::GPIO, 0);
-    clock_and_to_group(pac::resources::HDMA, 0);
-    clock_and_to_group(pac::resources::XPI0, 0);
-    clock_and_to_group(pac::resources::USB0, 0);
+    clock_add_to_group(pac::resources::WDG0, 0);
+    clock_add_to_group(pac::resources::WDG1, 0);
+    clock_add_to_group(pac::resources::MBX0, 0);
+    clock_add_to_group(pac::resources::TSNS, 0);
+    clock_add_to_group(pac::resources::CRC0, 0);
+    clock_add_to_group(pac::resources::ADC0, 0);
+    clock_add_to_group(pac::resources::ACMP, 0);
+    clock_add_to_group(pac::resources::KMAN, 0);
+    clock_add_to_group(pac::resources::GPIO, 0);
+    clock_add_to_group(pac::resources::HDMA, 0);
+    clock_add_to_group(pac::resources::XPI0, 0);
+    clock_add_to_group(pac::resources::USB0, 0);
 
     // Connect Group0 to CPU0
     SYSCTL.affiliate(0).set().write(|w| w.set_link(1 << 0));

--- a/src/sysctl/v6e.rs
+++ b/src/sysctl/v6e.rs
@@ -42,6 +42,7 @@ pub(crate) static mut CLOCKS: Clocks = Clocks {
 };
 
 #[derive(Clone, Copy, Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct Clocks {
     pub cpu0: Hertz,
     pub cpu1: Hertz,

--- a/src/sysctl/v6e.rs
+++ b/src/sysctl/v6e.rs
@@ -1,6 +1,6 @@
 //! System control, clocks, group links.
 
-use super::{clock_and_to_group, Pll};
+use super::{clock_add_to_group, Pll};
 use crate::pac;
 pub use crate::pac::sysctl::vals::ClockMux;
 use crate::pac::{PLLCTL, SYSCTL};
@@ -149,32 +149,32 @@ pub(crate) unsafe fn init(config: Config) {
         SYSCTL.global00().modify(|w| w.set_mux(2));
     }
 
-    clock_and_to_group(pac::resources::CPU0, 0);
-    clock_and_to_group(pac::resources::AHBP, 0);
-    clock_and_to_group(pac::resources::AXIC, 0);
-    clock_and_to_group(pac::resources::AXIN, 0);
-    clock_and_to_group(pac::resources::AXIS, 0);
+    clock_add_to_group(pac::resources::CPU0, 0);
+    clock_add_to_group(pac::resources::AHBP, 0);
+    clock_add_to_group(pac::resources::AXIC, 0);
+    clock_add_to_group(pac::resources::AXIN, 0);
+    clock_add_to_group(pac::resources::AXIS, 0);
 
-    clock_and_to_group(pac::resources::ROM0, 0);
-    clock_and_to_group(pac::resources::RAM0, 0);
-    clock_and_to_group(pac::resources::RAM1, 0);
-    clock_and_to_group(pac::resources::XPI0, 0);
-    clock_and_to_group(pac::resources::FEMC, 0);
+    clock_add_to_group(pac::resources::ROM0, 0);
+    clock_add_to_group(pac::resources::RAM0, 0);
+    clock_add_to_group(pac::resources::RAM1, 0);
+    clock_add_to_group(pac::resources::XPI0, 0);
+    clock_add_to_group(pac::resources::FEMC, 0);
 
-    clock_and_to_group(pac::resources::MCT0, 0);
-    clock_and_to_group(pac::resources::LMM0, 0);
-    clock_and_to_group(pac::resources::LMM1, 0);
+    clock_add_to_group(pac::resources::MCT0, 0);
+    clock_add_to_group(pac::resources::LMM0, 0);
+    clock_add_to_group(pac::resources::LMM1, 0);
 
-    clock_and_to_group(pac::resources::GPIO, 0);
-    clock_and_to_group(pac::resources::HDMA, 0);
-    clock_and_to_group(pac::resources::XDMA, 0);
-    clock_and_to_group(pac::resources::USB0, 0);
+    clock_add_to_group(pac::resources::GPIO, 0);
+    clock_add_to_group(pac::resources::HDMA, 0);
+    clock_add_to_group(pac::resources::XDMA, 0);
+    clock_add_to_group(pac::resources::USB0, 0);
 
     // Connect Group0 to CPU0
     SYSCTL.affiliate(0).set().write(|w| w.set_link(1 << 0));
 
-    clock_and_to_group(pac::resources::CPU1, 0);
-    clock_and_to_group(pac::resources::MCT1, 1);
+    clock_add_to_group(pac::resources::CPU1, 0);
+    clock_add_to_group(pac::resources::MCT1, 1);
 
     SYSCTL.affiliate(1).set().write(|w| w.set_link(1 << 1));
 


### PR DESCRIPTION
## Changes

- DMA v2 implementation for HPM53, HPM68, HPM6E
  - LLPointer is not supported yet
  - SwapTable is not supported yet
- Async UART driver
  - EH eco is added: embedded-hal-nb, embedded-io-async
  - Resource unlink when dropped
- New "IP feature" build cfg flags introduced, avoiding peripheral version style
- Refine README docs