### PR TITLE
Fix SPI async busy wait

### DIFF
--- a/examples/hpm5300evk/src/bin/async_spi_bug.rs
+++ b/examples/hpm5300evk/src/bin/async_spi_bug.rs
@@ -1,0 +1,50 @@
+#![no_main]
+#![no_std]
+#![feature(type_alias_impl_trait)]
+#![feature(impl_trait_in_assoc_type)]
+#![feature(abi_riscv_interrupt)]
+
+use embassy_time::{Duration, Timer};
+use hal::gpio::{Level, Output};
+use hal::peripherals;
+use hpm_hal::bind_interrupts;
+use hpm_hal::time::Hertz;
+use {defmt_rtt as _, hpm_hal as hal};
+
+bind_interrupts!(struct Irqs {
+    SPI1 => hal::spi::InterruptHandler<peripherals::SPI1>;
+});
+
+#[embassy_executor::main(entry = "hpm_hal::entry")]
+async fn main(_spawner: embassy_executor::Spawner) -> ! {
+    let config = hal::Config::default();
+    let p = hal::init(config);
+
+    let mut config = hal::spi::Config::default();
+    config.frequency = Hertz::mhz(2);
+    let mut spi = hal::spi::Spi::new_txonly(p.SPI1, p.PA27, p.PA29, Irqs, p.HDMA_CH0, config);
+
+    defmt::info!("go !");
+
+    spi.write(&[0xaa_u8; 1]).await.unwrap(); // lower values fail. larger(10 or so) values work
+
+    // The following lines are never reached
+
+    defmt::println!("bytes sent");
+
+    let mut led = Output::new(p.PA23, Level::Low, Default::default());
+    loop {
+        led.set_high();
+        Timer::after(Duration::from_millis(500)).await;
+        led.set_low();
+        Timer::after(Duration::from_millis(500)).await;
+        defmt::println!("tick");
+    }
+}
+
+#[panic_handler]
+unsafe fn panic(info: &core::panic::PanicInfo) -> ! {
+    defmt::println!("panic!\n {}", defmt::Debug2Format(info));
+
+    loop {}
+}

--- a/src/dma/util.rs
+++ b/src/dma/util.rs
@@ -48,6 +48,16 @@ impl<'d> ChannelAndRequest<'d> {
         Transfer::new_write_raw(&mut self.channel, self.request, buf, peri_addr, options)
     }
 
+    pub unsafe fn write_raw_with_spi_fix<'a, W: Word>(
+        &'a mut self,
+        buf: *const W,
+        buf_len: usize,
+        peri_addr: *mut W,
+        options: TransferOptions,
+    ) -> Transfer<'a> {
+        Transfer::new_write_raw_with_spi_fix(&mut self.channel, self.request, buf, buf_len, peri_addr, options)
+    }
+
     #[allow(dead_code)]
     pub unsafe fn write_repeated<'a, W: Word>(
         &'a mut self,

--- a/src/dma/util.rs
+++ b/src/dma/util.rs
@@ -48,16 +48,6 @@ impl<'d> ChannelAndRequest<'d> {
         Transfer::new_write_raw(&mut self.channel, self.request, buf, peri_addr, options)
     }
 
-    pub unsafe fn write_raw_with_spi_fix<'a, W: Word>(
-        &'a mut self,
-        buf: *const W,
-        buf_len: usize,
-        peri_addr: *mut W,
-        options: TransferOptions,
-    ) -> Transfer<'a> {
-        Transfer::new_write_raw_with_spi_fix(&mut self.channel, self.request, buf, buf_len, peri_addr, options)
-    }
-
     #[allow(dead_code)]
     pub unsafe fn write_repeated<'a, W: Word>(
         &'a mut self,

--- a/src/dma/v2.rs
+++ b/src/dma/v2.rs
@@ -441,6 +441,30 @@ impl<'a> Transfer<'a> {
         )
     }
 
+    /// Create a new write DMA transfer (memory to peripheral), using raw pointers.
+    pub unsafe fn new_write_raw_with_spi_fix<W: Word>(
+        channel: impl Peripheral<P = impl Channel> + 'a,
+        request: Request,
+        buf: *const W,
+        fixed_buf_len: usize,
+        peri_addr: *mut W,
+        options: TransferOptions,
+    ) -> Self {
+        into_ref!(channel);
+
+        Self::new_inner(
+            channel.map_into(),
+            request,
+            Dir::MemoryToPeripheral,
+            peri_addr as *const u32,
+            buf as *mut u32,
+            fixed_buf_len,
+            true,
+            W::size(),
+            options,
+        )
+    }
+
     /// Create a new write DMA transfer (memory to peripheral), writing the same value repeatedly.
     pub unsafe fn new_write_repeated<W: Word>(
         channel: impl Peripheral<P = impl Channel> + 'a,

--- a/src/spi/mod.rs
+++ b/src/spi/mod.rs
@@ -55,8 +55,6 @@ impl<T: Instance> interrupt::typelevel::Handler<T::Interrupt> for InterruptHandl
 unsafe fn on_interrupt(r: pac::spi::Spi, s: &'static State) {
     let status = r.intr_st().read();
 
-    defmt::info!("in irq");
-
     if status.endint() {
         s.waker.wake();
 

--- a/src/spi/mod.rs
+++ b/src/spi/mod.rs
@@ -56,8 +56,6 @@ impl<T: Instance> interrupt::typelevel::Handler<T::Interrupt> for InterruptHandl
 unsafe fn on_interrupt(r: pac::spi::Spi, s: &'static State) {
     let status = r.intr_st().read();
 
-    defmt::println!("in irq");
-
     if status.endint() {
         s.waker.wake();
 

--- a/src/spi/mod.rs
+++ b/src/spi/mod.rs
@@ -5,11 +5,13 @@
 //! - SPI_CS_SELECT: v53, v68,
 //! - SPI_SUPPORT_DIRECTIO: v53, v68
 
+use core::future::poll_fn;
 use core::marker::PhantomData;
 use core::ptr;
+use core::sync::atomic::{compiler_fence, Ordering};
+use core::task::Poll;
 
 use embassy_futures::join::join;
-use embassy_futures::yield_now;
 use embassy_hal_internal::{into_ref, Peripheral, PeripheralRef};
 use embassy_sync::waitqueue::AtomicWaker;
 // re-export
@@ -18,9 +20,11 @@ pub use embedded_hal::spi::{Mode, MODE_0, MODE_1, MODE_2, MODE_3};
 use self::consts::*;
 use crate::dma::{self, word, ChannelAndRequest};
 use crate::gpio::AnyPin;
+use crate::interrupt::typelevel::Interrupt as _;
 use crate::mode::{Async, Blocking, Mode as PeriMode};
 pub use crate::pac::spi::vals::{AddrLen, AddrPhaseFormat, DataPhaseFormat, TransMode};
 use crate::time::Hertz;
+use crate::{interrupt, pac};
 
 #[cfg(any(hpm53, hpm68, hpm6e))]
 mod consts {
@@ -33,7 +37,34 @@ mod consts {
     pub const FIFO_SIZE: usize = 4;
 }
 
-// NOTE: SPI end interrupt is not working under DMA mode
+// - MARK: interrupt handler
+
+/// Interrupt handler.
+pub struct InterruptHandler<T: Instance> {
+    _phantom: PhantomData<T>,
+}
+
+impl<T: Instance> interrupt::typelevel::Handler<T::Interrupt> for InterruptHandler<T> {
+    unsafe fn on_interrupt() {
+        on_interrupt(T::info().regs, T::state());
+
+        // PLIC ack is handled by typelevel Handler
+    }
+}
+
+unsafe fn on_interrupt(r: pac::spi::Spi, s: &'static State) {
+    let status = r.intr_st().read();
+
+    defmt::info!("in irq");
+
+    if status.endint() {
+        s.waker.wake();
+
+        r.intr_en().modify(|w| w.set_endinten(false));
+    }
+
+    r.intr_st().write_value(status); // W1C
+}
 
 // - MARK: Helper enums
 
@@ -378,6 +409,7 @@ impl<'d> Spi<'d, Async> {
         sclk: impl Peripheral<P = impl SclkPin<T>> + 'd,
         mosi: impl Peripheral<P = impl MosiPin<T>> + 'd,
         miso: impl Peripheral<P = impl MisoPin<T>> + 'd,
+        _irq: impl interrupt::typelevel::Binding<T::Interrupt, InterruptHandler<T>> + 'd,
         tx_dma: impl Peripheral<P = impl TxDma<T>> + 'd,
         rx_dma: impl Peripheral<P = impl RxDma<T>> + 'd,
         config: Config,
@@ -410,6 +442,7 @@ impl<'d> Spi<'d, Async> {
         peri: impl Peripheral<P = T> + 'd,
         sclk: impl Peripheral<P = impl SclkPin<T>> + 'd,
         miso: impl Peripheral<P = impl MisoPin<T>> + 'd,
+        _irq: impl interrupt::typelevel::Binding<T::Interrupt, InterruptHandler<T>> + 'd,
         rx_dma: impl Peripheral<P = impl RxDma<T>> + 'd,
         config: Config,
     ) -> Self {
@@ -441,6 +474,7 @@ impl<'d> Spi<'d, Async> {
         peri: impl Peripheral<P = T> + 'd,
         sclk: impl Peripheral<P = impl SclkPin<T>> + 'd,
         mosi: impl Peripheral<P = impl MosiPin<T>> + 'd,
+        _irq: impl interrupt::typelevel::Binding<T::Interrupt, InterruptHandler<T>> + 'd,
         tx_dma: impl Peripheral<P = impl TxDma<T>> + 'd,
         config: Config,
     ) -> Self {
@@ -499,11 +533,18 @@ impl<'d> Spi<'d, Async> {
             return Ok(());
         }
 
+        defmt::info!("write spi");
+
         let r = self.info.regs;
+        let s = self.state;
 
         self.set_word_size(W::CONFIG);
 
         self.configure_transfer(data.len(), 0, &TransferConfig::default())?;
+
+        r.intr_en().modify(|w| {
+            w.set_endinten(true);
+        });
 
         r.ctrl().modify(|w| w.set_txdmaen(true));
 
@@ -514,13 +555,17 @@ impl<'d> Spi<'d, Async> {
 
         tx_f.await;
 
-        r.ctrl().modify(|w| w.set_txdmaen(false));
+        poll_fn(move |cx| {
+            if r.intr_en().read().endinten() {
+                return Poll::Pending;
+            } else {
+                s.waker.register(cx.waker());
+                return Poll::Ready(());
+            }
+        })
+        .await;
 
-        // NOTE: SPI end(finish) interrupt is not working under DMA mode, a busy-loop wait is necessary for TX mode.
-        // The same goes for `transfer` fn.
-        while r.status().read().spiactive() {
-            yield_now().await;
-        }
+        r.ctrl().modify(|w| w.set_txdmaen(false));
 
         Ok(())
     }
@@ -584,11 +629,6 @@ impl<'d> Spi<'d, Async> {
             w.set_txdmaen(false);
         });
 
-        // See `write`
-        while r.status().read().spiactive() {
-            yield_now().await;
-        }
-
         Ok(())
     }
 
@@ -638,6 +678,10 @@ impl<'d, M: PeriMode> Spi<'d, M> {
         };
 
         this.enable_and_configure(&config).unwrap();
+
+        unsafe {
+            T::Interrupt::enable();
+        }
 
         this
     }


### PR DESCRIPTION
See-also #33 

only async write is fixed.

To get END irq work:

- ~~DMA Bust must 1 for SPI~~
- ~~DMA transize must be  **actual_size + 1** for SPI~~

**UPDATE**

After some investigation: 

- Only special values trigger this bug
- SPI END interrupt state is marked (INTRST.ENDINT is set), SPI interrupt is enabled(both peripheral and PLIC). But irq handler is never reached
